### PR TITLE
Align D1 schema with backend runtime and lock backend/database/contract sources of truth

### DIFF
--- a/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/README.md
+++ b/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/README.md
@@ -1,6 +1,27 @@
 # Esquilo Invest - Cloudflare Worker + D1 Starter
 
-Starter inicial para a nova versão do backend do Esquilo Invest em **Cloudflare Workers + D1**.
+Base executavel oficial da fase de transicao do backend novo em **Cloudflare Workers + D1**.
+
+## Papel desta pasta na arquitetura
+
+Esta pasta nao e mais lida como demo descartavel.
+
+Ela e hoje:
+
+- a base executavel oficial da fase atual
+- o lugar onde as rotas novas precisam funcionar de verdade
+
+Ela nao e:
+
+- a casa final da arquitetura
+- a fonte oficial de schema
+- a fonte oficial de contrato compartilhado
+
+As fontes oficiais fora desta pasta sao:
+
+- contrato HTTP: `../../services/api/openapi.yaml`
+- schema do dominio: `../../database/d1/schema.sql`
+- contratos compartilhados: `../../packages/contracts/`
 
 ## O que tem aqui
 
@@ -22,13 +43,20 @@ Starter inicial para a nova versão do backend do Esquilo Invest em **Cloudflare
 
 ## Observação importante
 
-Isso é um **starter de verdade**, mas ainda não é backend completo de produção.
+Isso e um **starter de verdade**, mas ainda nao e backend completo de producao.
 Ele já organiza:
 - contratos
 - envelopes de resposta
 - validação básica de rotas
 - estrutura de arquivo
 - base SQL
+
+Regra da fase:
+
+- implementar aqui o que precisa rodar agora
+- decidir contrato em `services/api`
+- decidir schema em `database/d1`
+- evitar que os arquivos locais desta pasta virem uma nova fonte paralela de verdade
 
 O que ainda falta endurecer:
 - autenticação real
@@ -42,7 +70,7 @@ O que ainda falta endurecer:
 ## Como usar
 
 1. Criar o banco D1
-2. Aplicar `schema.sql`
+2. Aplicar preferencialmente `../../database/d1/schema.sql`
 3. Ajustar `wrangler.toml`
 4. Rodar localmente
 5. Implementar os repositórios reais por rota

--- a/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/schema.sql
+++ b/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/schema.sql
@@ -1,41 +1,89 @@
 PRAGMA foreign_keys = ON;
 
+-- Fonte de verdade do schema: `../../database/d1/schema.sql`
+-- Este arquivo e um espelho para facilitar `wrangler d1 execute --file=schema.sql` dentro do starter.
+
 CREATE TABLE IF NOT EXISTS users (
   id TEXT PRIMARY KEY,
-  auth_provider TEXT,
-  auth_provider_user_id TEXT,
-  display_name TEXT,
+  cpf TEXT,
   email TEXT,
-  status TEXT NOT NULL DEFAULT 'active',
+  password_hash TEXT,
+  display_name TEXT,
+  email_verification_sent_at TEXT,
+  email_verified_at TEXT,
+  failed_login_attempts INTEGER NOT NULL DEFAULT 0,
+  login_locked_until TEXT,
+  last_login_at TEXT,
+  status TEXT NOT NULL DEFAULT 'ACTIVE',
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_users_auth_provider
-  ON users(auth_provider, auth_provider_user_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_cpf ON users(cpf);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_email ON users(email);
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_users_email
-  ON users(email);
-
-CREATE TABLE IF NOT EXISTS portfolios (
+CREATE TABLE IF NOT EXISTS auth_sessions (
   id TEXT PRIMARY KEY,
   user_id TEXT NOT NULL,
-  name TEXT NOT NULL,
-  is_primary INTEGER NOT NULL DEFAULT 0 CHECK (is_primary IN (0,1)),
-  status TEXT NOT NULL DEFAULT 'active',
+  session_token_hash TEXT NOT NULL,
+  device_fingerprint TEXT,
+  user_agent TEXT,
+  ip_address TEXT,
+  remember_device INTEGER NOT NULL DEFAULT 0 CHECK (remember_device IN (0,1)),
+  expires_at TEXT NOT NULL,
+  revoked_at TEXT,
+  revoke_reason TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  last_seen_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_auth_sessions_token_hash ON auth_sessions(session_token_hash);
+CREATE INDEX IF NOT EXISTS idx_auth_sessions_user_id ON auth_sessions(user_id);
+CREATE INDEX IF NOT EXISTS idx_auth_sessions_expires_at ON auth_sessions(expires_at);
+
+CREATE TABLE IF NOT EXISTS auth_recovery_requests (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  channel TEXT NOT NULL,
+  status TEXT NOT NULL,
+  token_hash TEXT NOT NULL,
+  delivery_provider TEXT,
+  expires_at TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_auth_recovery_token_hash ON auth_recovery_requests(token_hash);
+CREATE INDEX IF NOT EXISTS idx_auth_recovery_user_id ON auth_recovery_requests(user_id);
+
+CREATE TABLE IF NOT EXISTS user_financial_context (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  financial_goal TEXT,
+  monthly_income_range TEXT,
+  monthly_investment_target NUMERIC,
+  available_to_invest NUMERIC,
+  risk_profile TEXT,
+  risk_profile_self_declared TEXT,
+  risk_profile_quiz_result TEXT,
+  risk_profile_effective TEXT,
+  investment_horizon TEXT,
+  platforms_used_json TEXT,
+  display_preferences_json TEXT,
+  onboarding_step TEXT,
+  onboarding_completed_at TEXT,
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );
 
-CREATE INDEX IF NOT EXISTS idx_portfolios_user_id ON portfolios(user_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_user_financial_context_user_id ON user_financial_context(user_id);
 
 CREATE TABLE IF NOT EXISTS platforms (
   id TEXT PRIMARY KEY,
   code TEXT NOT NULL,
   name TEXT NOT NULL,
-  platform_kind TEXT,
-  is_active INTEGER NOT NULL DEFAULT 1 CHECK (is_active IN (0,1)),
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
@@ -46,8 +94,6 @@ CREATE TABLE IF NOT EXISTS asset_types (
   id TEXT PRIMARY KEY,
   code TEXT NOT NULL,
   name TEXT NOT NULL,
-  sort_order INTEGER NOT NULL DEFAULT 0,
-  is_active INTEGER NOT NULL DEFAULT 1 CHECK (is_active IN (0,1)),
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -56,67 +102,52 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_asset_types_code ON asset_types(code);
 CREATE TABLE IF NOT EXISTS assets (
   id TEXT PRIMARY KEY,
   asset_type_id TEXT NOT NULL,
-  platform_id TEXT,
   code TEXT,
-  external_code TEXT,
-  cnpj TEXT,
-  isin TEXT,
   name TEXT NOT NULL,
   normalized_name TEXT,
-  custom_name TEXT,
-  is_custom INTEGER NOT NULL DEFAULT 0 CHECK (is_custom IN (0,1)),
-  currency_code TEXT NOT NULL DEFAULT 'BRL',
   metadata_json TEXT,
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  FOREIGN KEY (asset_type_id) REFERENCES asset_types(id),
-  FOREIGN KEY (platform_id) REFERENCES platforms(id)
+  FOREIGN KEY (asset_type_id) REFERENCES asset_types(id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_assets_asset_type_id ON assets(asset_type_id);
-CREATE INDEX IF NOT EXISTS idx_assets_platform_id ON assets(platform_id);
 CREATE INDEX IF NOT EXISTS idx_assets_code ON assets(code);
 CREATE INDEX IF NOT EXISTS idx_assets_normalized_name ON assets(normalized_name);
 
-CREATE TABLE IF NOT EXISTS user_financial_context (
+CREATE TABLE IF NOT EXISTS portfolios (
   id TEXT PRIMARY KEY,
   user_id TEXT NOT NULL,
-  financial_goal TEXT,
-  monthly_income_range TEXT,
-  monthly_investment_target NUMERIC,
-  available_to_invest NUMERIC,
-  risk_profile TEXT,
-  investment_horizon TEXT,
-  platforms_used_json TEXT,
-  display_preferences_json TEXT,
+  name TEXT NOT NULL,
+  base_currency TEXT NOT NULL DEFAULT 'BRL',
+  is_primary INTEGER NOT NULL DEFAULT 0 CHECK (is_primary IN (0,1)),
+  status TEXT NOT NULL DEFAULT 'active',
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_user_financial_context_user_id ON user_financial_context(user_id);
+CREATE INDEX IF NOT EXISTS idx_portfolios_user_id ON portfolios(user_id);
+CREATE INDEX IF NOT EXISTS idx_portfolios_is_primary ON portfolios(is_primary);
 
 CREATE TABLE IF NOT EXISTS imports (
   id TEXT PRIMARY KEY,
   user_id TEXT NOT NULL,
   portfolio_id TEXT,
   origin TEXT NOT NULL,
-  source_platform_id TEXT,
+  status TEXT NOT NULL,
   file_name TEXT,
-  file_storage_key TEXT,
   mime_type TEXT,
-  checksum_sha256 TEXT,
-  status TEXT NOT NULL DEFAULT 'pending',
   total_rows INTEGER NOT NULL DEFAULT 0,
   valid_rows INTEGER NOT NULL DEFAULT 0,
   invalid_rows INTEGER NOT NULL DEFAULT 0,
   duplicate_rows INTEGER NOT NULL DEFAULT 0,
-  error_log TEXT,
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT,
+  finished_at TEXT,
   FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
-  FOREIGN KEY (portfolio_id) REFERENCES portfolios(id) ON DELETE SET NULL,
-  FOREIGN KEY (source_platform_id) REFERENCES platforms(id)
+  FOREIGN KEY (portfolio_id) REFERENCES portfolios(id) ON DELETE SET NULL
 );
 
 CREATE INDEX IF NOT EXISTS idx_imports_user_id ON imports(user_id);
@@ -127,45 +158,39 @@ CREATE TABLE IF NOT EXISTS import_rows (
   id TEXT PRIMARY KEY,
   import_id TEXT NOT NULL,
   row_number INTEGER NOT NULL,
-  status TEXT NOT NULL DEFAULT 'parsed',
-  raw_row_json TEXT NOT NULL,
-  normalized_row_json TEXT,
-  resolved_asset_id TEXT,
-  dedup_key TEXT,
-  validation_errors_json TEXT,
-  conflict_summary_json TEXT,
+  source_payload_json TEXT,
+  normalized_payload_json TEXT,
+  resolution_status TEXT NOT NULL DEFAULT 'NORMALIZED',
+  error_message TEXT,
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  FOREIGN KEY (import_id) REFERENCES imports(id) ON DELETE CASCADE,
-  FOREIGN KEY (resolved_asset_id) REFERENCES assets(id)
+  FOREIGN KEY (import_id) REFERENCES imports(id) ON DELETE CASCADE
 );
 
 CREATE INDEX IF NOT EXISTS idx_import_rows_import_id ON import_rows(import_id);
-CREATE INDEX IF NOT EXISTS idx_import_rows_dedup_key ON import_rows(dedup_key);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_import_rows_import_row_number ON import_rows(import_id, row_number);
 
 CREATE TABLE IF NOT EXISTS portfolio_positions (
   id TEXT PRIMARY KEY,
   portfolio_id TEXT NOT NULL,
   asset_id TEXT NOT NULL,
   platform_id TEXT,
-  source_import_id TEXT,
+  source_kind TEXT NOT NULL,
   status TEXT NOT NULL DEFAULT 'active',
-  quantity NUMERIC NOT NULL DEFAULT 0,
+  quantity NUMERIC,
   average_price NUMERIC,
   current_price NUMERIC,
   invested_amount NUMERIC,
-  current_value NUMERIC,
-  target_price NUMERIC,
-  stop_loss NUMERIC,
-  started_at TEXT,
-  observed_at TEXT,
+  current_amount NUMERIC,
+  category_label TEXT,
   notes TEXT,
-  raw_payload_json TEXT,
+  stop_loss NUMERIC,
+  target_price NUMERIC,
+  profitability NUMERIC,
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY (portfolio_id) REFERENCES portfolios(id) ON DELETE CASCADE,
   FOREIGN KEY (asset_id) REFERENCES assets(id),
-  FOREIGN KEY (platform_id) REFERENCES platforms(id),
-  FOREIGN KEY (source_import_id) REFERENCES imports(id) ON DELETE SET NULL
+  FOREIGN KEY (platform_id) REFERENCES platforms(id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_portfolio_positions_portfolio_id ON portfolio_positions(portfolio_id);
@@ -181,8 +206,6 @@ CREATE TABLE IF NOT EXISTS portfolio_snapshots (
   total_invested NUMERIC,
   total_profit_loss NUMERIC,
   total_profit_loss_pct NUMERIC,
-  source_kind TEXT NOT NULL DEFAULT 'system',
-  metadata_json TEXT,
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY (portfolio_id) REFERENCES portfolios(id) ON DELETE CASCADE,
   FOREIGN KEY (import_id) REFERENCES imports(id) ON DELETE SET NULL
@@ -190,24 +213,18 @@ CREATE TABLE IF NOT EXISTS portfolio_snapshots (
 
 CREATE INDEX IF NOT EXISTS idx_portfolio_snapshots_portfolio_id ON portfolio_snapshots(portfolio_id);
 CREATE INDEX IF NOT EXISTS idx_portfolio_snapshots_reference_date ON portfolio_snapshots(reference_date);
+CREATE INDEX IF NOT EXISTS idx_portfolio_snapshots_import_id ON portfolio_snapshots(import_id);
 
 CREATE TABLE IF NOT EXISTS portfolio_snapshot_positions (
   id TEXT PRIMARY KEY,
   snapshot_id TEXT NOT NULL,
   asset_id TEXT NOT NULL,
-  platform_id TEXT,
-  quantity NUMERIC NOT NULL DEFAULT 0,
-  average_price NUMERIC,
-  current_price NUMERIC,
-  invested_amount NUMERIC,
+  quantity NUMERIC,
+  unit_price NUMERIC,
   current_value NUMERIC,
-  allocation_pct NUMERIC,
-  performance_pct NUMERIC,
-  metadata_json TEXT,
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY (snapshot_id) REFERENCES portfolio_snapshots(id) ON DELETE CASCADE,
-  FOREIGN KEY (asset_id) REFERENCES assets(id),
-  FOREIGN KEY (platform_id) REFERENCES platforms(id)
+  FOREIGN KEY (asset_id) REFERENCES assets(id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_snapshot_positions_snapshot_id ON portfolio_snapshot_positions(snapshot_id);
@@ -217,15 +234,14 @@ CREATE TABLE IF NOT EXISTS portfolio_analyses (
   id TEXT PRIMARY KEY,
   portfolio_id TEXT NOT NULL,
   snapshot_id TEXT NOT NULL,
-  status TEXT NOT NULL DEFAULT 'generated',
   score_value NUMERIC,
   score_status TEXT,
   primary_problem TEXT,
   primary_action TEXT,
+  portfolio_decision TEXT,
+  action_plan_text TEXT,
   summary_text TEXT,
-  ai_context_json TEXT,
-  raw_ai_response TEXT,
-  generated_by TEXT NOT NULL DEFAULT 'system',
+  messaging_json TEXT,
   generated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY (portfolio_id) REFERENCES portfolios(id) ON DELETE CASCADE,
   FOREIGN KEY (snapshot_id) REFERENCES portfolio_snapshots(id) ON DELETE CASCADE
@@ -233,81 +249,35 @@ CREATE TABLE IF NOT EXISTS portfolio_analyses (
 
 CREATE INDEX IF NOT EXISTS idx_portfolio_analyses_portfolio_id ON portfolio_analyses(portfolio_id);
 CREATE INDEX IF NOT EXISTS idx_portfolio_analyses_snapshot_id ON portfolio_analyses(snapshot_id);
+CREATE INDEX IF NOT EXISTS idx_portfolio_analyses_generated_at ON portfolio_analyses(generated_at);
 
 CREATE TABLE IF NOT EXISTS analysis_insights (
   id TEXT PRIMARY KEY,
   analysis_id TEXT NOT NULL,
-  insight_kind TEXT NOT NULL,
-  title TEXT NOT NULL,
-  body TEXT NOT NULL,
-  severity TEXT,
-  sort_order INTEGER NOT NULL DEFAULT 0,
-  related_asset_id TEXT,
-  related_category_code TEXT,
-  metadata_json TEXT,
+  insight_type TEXT NOT NULL,
+  title TEXT,
+  message TEXT NOT NULL,
+  priority INTEGER,
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  FOREIGN KEY (analysis_id) REFERENCES portfolio_analyses(id) ON DELETE CASCADE,
-  FOREIGN KEY (related_asset_id) REFERENCES assets(id)
+  FOREIGN KEY (analysis_id) REFERENCES portfolio_analyses(id) ON DELETE CASCADE
 );
 
 CREATE INDEX IF NOT EXISTS idx_analysis_insights_analysis_id ON analysis_insights(analysis_id);
-
-CREATE TABLE IF NOT EXISTS external_data_sources (
-  id TEXT PRIMARY KEY,
-  code TEXT NOT NULL,
-  name TEXT NOT NULL,
-  source_kind TEXT NOT NULL,
-  status TEXT NOT NULL DEFAULT 'active',
-  config_json TEXT,
-  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
-
-CREATE UNIQUE INDEX IF NOT EXISTS idx_external_data_sources_code ON external_data_sources(code);
-
-CREATE TABLE IF NOT EXISTS external_market_references (
-  id TEXT PRIMARY KEY,
-  source_id TEXT NOT NULL,
-  reference_code TEXT NOT NULL,
-  reference_name TEXT NOT NULL,
-  asset_type_scope TEXT,
-  reference_date TEXT NOT NULL,
-  value NUMERIC,
-  value_pct NUMERIC,
-  currency_code TEXT NOT NULL DEFAULT 'BRL',
-  cache_status TEXT,
-  raw_payload_json TEXT,
-  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  FOREIGN KEY (source_id) REFERENCES external_data_sources(id)
-);
-
-CREATE INDEX IF NOT EXISTS idx_external_market_references_source_id ON external_market_references(source_id);
-CREATE INDEX IF NOT EXISTS idx_external_market_references_ref_date ON external_market_references(reference_date);
-CREATE INDEX IF NOT EXISTS idx_external_market_references_code ON external_market_references(reference_code);
+CREATE INDEX IF NOT EXISTS idx_analysis_insights_priority ON analysis_insights(priority);
 
 CREATE TABLE IF NOT EXISTS operational_events (
   id TEXT PRIMARY KEY,
   user_id TEXT,
   portfolio_id TEXT,
   event_type TEXT NOT NULL,
-  event_status TEXT NOT NULL DEFAULT 'info',
-  entity_type TEXT,
-  entity_id TEXT,
-  import_id TEXT,
-  snapshot_id TEXT,
-  analysis_id TEXT,
+  event_status TEXT NOT NULL,
   message TEXT,
   details_json TEXT,
   occurred_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL,
-  FOREIGN KEY (portfolio_id) REFERENCES portfolios(id) ON DELETE SET NULL,
-  FOREIGN KEY (import_id) REFERENCES imports(id) ON DELETE SET NULL,
-  FOREIGN KEY (snapshot_id) REFERENCES portfolio_snapshots(id) ON DELETE SET NULL,
-  FOREIGN KEY (analysis_id) REFERENCES portfolio_analyses(id) ON DELETE SET NULL
+  FOREIGN KEY (portfolio_id) REFERENCES portfolios(id) ON DELETE SET NULL
 );
 
 CREATE INDEX IF NOT EXISTS idx_operational_events_user_id ON operational_events(user_id);
 CREATE INDEX IF NOT EXISTS idx_operational_events_portfolio_id ON operational_events(portfolio_id);
 CREATE INDEX IF NOT EXISTS idx_operational_events_occurred_at ON operational_events(occurred_at);
-CREATE INDEX IF NOT EXISTS idx_operational_events_event_type ON operational_events(event_type);

--- a/database/d1/README.md
+++ b/database/d1/README.md
@@ -1,6 +1,13 @@
 # D1
 
-Esta pasta vai receber a estrutura do banco D1.
+Esta pasta e a fonte oficial do schema do dominio no D1.
+
+Regra:
+
+- decisao de tabela, relacao e indice nasce aqui
+- seed, migration e view de apoio tambem pertencem aqui
+- se houver divergencia com schema do starter, prevalece o que estiver nesta pasta
+- schema em `OLD/` serve apenas como referencia historica
 
 Exemplos:
 - schema.sql

--- a/database/d1/schema.sql
+++ b/database/d1/schema.sql
@@ -1,67 +1,170 @@
--- Esquilo Invest / Quebra_Nozes
--- Schema inicial do D1
-
 PRAGMA foreign_keys = ON;
 
 CREATE TABLE IF NOT EXISTS users (
   id TEXT PRIMARY KEY,
-  display_name TEXT NOT NULL,
+  cpf TEXT,
   email TEXT,
+  password_hash TEXT,
+  display_name TEXT,
+  email_verification_sent_at TEXT,
+  email_verified_at TEXT,
+  failed_login_attempts INTEGER NOT NULL DEFAULT 0,
+  login_locked_until TEXT,
+  last_login_at TEXT,
+  status TEXT NOT NULL DEFAULT 'ACTIVE',
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_cpf ON users(cpf);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_email ON users(email);
+
+CREATE TABLE IF NOT EXISTS auth_sessions (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  session_token_hash TEXT NOT NULL,
+  device_fingerprint TEXT,
+  user_agent TEXT,
+  ip_address TEXT,
+  remember_device INTEGER NOT NULL DEFAULT 0 CHECK (remember_device IN (0,1)),
+  expires_at TEXT NOT NULL,
+  revoked_at TEXT,
+  revoke_reason TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  last_seen_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_auth_sessions_token_hash ON auth_sessions(session_token_hash);
+CREATE INDEX IF NOT EXISTS idx_auth_sessions_user_id ON auth_sessions(user_id);
+CREATE INDEX IF NOT EXISTS idx_auth_sessions_expires_at ON auth_sessions(expires_at);
+
+CREATE TABLE IF NOT EXISTS auth_recovery_requests (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  channel TEXT NOT NULL,
+  status TEXT NOT NULL,
+  token_hash TEXT NOT NULL,
+  delivery_provider TEXT,
+  expires_at TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_auth_recovery_token_hash ON auth_recovery_requests(token_hash);
+CREATE INDEX IF NOT EXISTS idx_auth_recovery_user_id ON auth_recovery_requests(user_id);
+
 CREATE TABLE IF NOT EXISTS user_financial_context (
-  user_id TEXT PRIMARY KEY,
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
   financial_goal TEXT,
   monthly_income_range TEXT,
-  monthly_investment_target REAL,
-  available_to_invest REAL,
+  monthly_investment_target NUMERIC,
+  available_to_invest NUMERIC,
   risk_profile TEXT,
+  risk_profile_self_declared TEXT,
+  risk_profile_quiz_result TEXT,
+  risk_profile_effective TEXT,
   investment_horizon TEXT,
   platforms_used_json TEXT,
   display_preferences_json TEXT,
+  onboarding_step TEXT,
+  onboarding_completed_at TEXT,
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  FOREIGN KEY (user_id) REFERENCES users(id)
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_user_financial_context_user_id ON user_financial_context(user_id);
 
 CREATE TABLE IF NOT EXISTS platforms (
   id TEXT PRIMARY KEY,
-  code TEXT NOT NULL UNIQUE,
+  code TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_platforms_code ON platforms(code);
+
+CREATE TABLE IF NOT EXISTS asset_types (
+  id TEXT PRIMARY KEY,
+  code TEXT NOT NULL,
   name TEXT NOT NULL,
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE TABLE IF NOT EXISTS asset_types (
-  id TEXT PRIMARY KEY,
-  code TEXT NOT NULL UNIQUE,
-  name TEXT NOT NULL,
-  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_asset_types_code ON asset_types(code);
 
 CREATE TABLE IF NOT EXISTS assets (
   id TEXT PRIMARY KEY,
   asset_type_id TEXT NOT NULL,
   code TEXT,
   name TEXT NOT NULL,
-  external_code TEXT,
+  normalized_name TEXT,
   metadata_json TEXT,
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY (asset_type_id) REFERENCES asset_types(id)
 );
 
+CREATE INDEX IF NOT EXISTS idx_assets_asset_type_id ON assets(asset_type_id);
+CREATE INDEX IF NOT EXISTS idx_assets_code ON assets(code);
+CREATE INDEX IF NOT EXISTS idx_assets_normalized_name ON assets(normalized_name);
+
 CREATE TABLE IF NOT EXISTS portfolios (
   id TEXT PRIMARY KEY,
   user_id TEXT NOT NULL,
   name TEXT NOT NULL,
   base_currency TEXT NOT NULL DEFAULT 'BRL',
+  is_primary INTEGER NOT NULL DEFAULT 0 CHECK (is_primary IN (0,1)),
   status TEXT NOT NULL DEFAULT 'active',
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  FOREIGN KEY (user_id) REFERENCES users(id)
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );
+
+CREATE INDEX IF NOT EXISTS idx_portfolios_user_id ON portfolios(user_id);
+CREATE INDEX IF NOT EXISTS idx_portfolios_is_primary ON portfolios(is_primary);
+
+CREATE TABLE IF NOT EXISTS imports (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  portfolio_id TEXT,
+  origin TEXT NOT NULL,
+  status TEXT NOT NULL,
+  file_name TEXT,
+  mime_type TEXT,
+  total_rows INTEGER NOT NULL DEFAULT 0,
+  valid_rows INTEGER NOT NULL DEFAULT 0,
+  invalid_rows INTEGER NOT NULL DEFAULT 0,
+  duplicate_rows INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT,
+  finished_at TEXT,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  FOREIGN KEY (portfolio_id) REFERENCES portfolios(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_imports_user_id ON imports(user_id);
+CREATE INDEX IF NOT EXISTS idx_imports_portfolio_id ON imports(portfolio_id);
+CREATE INDEX IF NOT EXISTS idx_imports_status ON imports(status);
+
+CREATE TABLE IF NOT EXISTS import_rows (
+  id TEXT PRIMARY KEY,
+  import_id TEXT NOT NULL,
+  row_number INTEGER NOT NULL,
+  source_payload_json TEXT,
+  normalized_payload_json TEXT,
+  resolution_status TEXT NOT NULL DEFAULT 'NORMALIZED',
+  error_message TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (import_id) REFERENCES imports(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_import_rows_import_id ON import_rows(import_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_import_rows_import_row_number ON import_rows(import_id, row_number);
 
 CREATE TABLE IF NOT EXISTS portfolio_positions (
   id TEXT PRIMARY KEY,
@@ -70,134 +173,108 @@ CREATE TABLE IF NOT EXISTS portfolio_positions (
   platform_id TEXT,
   source_kind TEXT NOT NULL,
   status TEXT NOT NULL DEFAULT 'active',
-  quantity REAL,
-  average_price REAL,
-  current_price REAL,
-  invested_amount REAL,
-  current_value REAL,
+  quantity NUMERIC,
+  average_price NUMERIC,
+  current_price NUMERIC,
+  invested_amount NUMERIC,
+  current_amount NUMERIC,
+  category_label TEXT,
   notes TEXT,
-  reference_date TEXT,
+  stop_loss NUMERIC,
+  target_price NUMERIC,
+  profitability NUMERIC,
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  FOREIGN KEY (portfolio_id) REFERENCES portfolios(id),
+  FOREIGN KEY (portfolio_id) REFERENCES portfolios(id) ON DELETE CASCADE,
   FOREIGN KEY (asset_id) REFERENCES assets(id),
   FOREIGN KEY (platform_id) REFERENCES platforms(id)
 );
 
+CREATE INDEX IF NOT EXISTS idx_portfolio_positions_portfolio_id ON portfolio_positions(portfolio_id);
+CREATE INDEX IF NOT EXISTS idx_portfolio_positions_asset_id ON portfolio_positions(asset_id);
+CREATE INDEX IF NOT EXISTS idx_portfolio_positions_platform_id ON portfolio_positions(platform_id);
+
 CREATE TABLE IF NOT EXISTS portfolio_snapshots (
   id TEXT PRIMARY KEY,
   portfolio_id TEXT NOT NULL,
+  import_id TEXT,
   reference_date TEXT NOT NULL,
-  total_equity REAL,
-  total_invested REAL,
-  total_profit_loss REAL,
-  total_profit_loss_pct REAL,
-  source_kind TEXT,
+  total_equity NUMERIC,
+  total_invested NUMERIC,
+  total_profit_loss NUMERIC,
+  total_profit_loss_pct NUMERIC,
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  FOREIGN KEY (portfolio_id) REFERENCES portfolios(id)
+  FOREIGN KEY (portfolio_id) REFERENCES portfolios(id) ON DELETE CASCADE,
+  FOREIGN KEY (import_id) REFERENCES imports(id) ON DELETE SET NULL
 );
+
+CREATE INDEX IF NOT EXISTS idx_portfolio_snapshots_portfolio_id ON portfolio_snapshots(portfolio_id);
+CREATE INDEX IF NOT EXISTS idx_portfolio_snapshots_reference_date ON portfolio_snapshots(reference_date);
+CREATE INDEX IF NOT EXISTS idx_portfolio_snapshots_import_id ON portfolio_snapshots(import_id);
 
 CREATE TABLE IF NOT EXISTS portfolio_snapshot_positions (
   id TEXT PRIMARY KEY,
   snapshot_id TEXT NOT NULL,
   asset_id TEXT NOT NULL,
-  quantity REAL,
-  average_price REAL,
-  current_price REAL,
-  invested_amount REAL,
-  current_value REAL,
-  performance_pct REAL,
-  allocation_pct REAL,
-  metadata_json TEXT,
+  quantity NUMERIC,
+  unit_price NUMERIC,
+  current_value NUMERIC,
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  FOREIGN KEY (snapshot_id) REFERENCES portfolio_snapshots(id),
+  FOREIGN KEY (snapshot_id) REFERENCES portfolio_snapshots(id) ON DELETE CASCADE,
   FOREIGN KEY (asset_id) REFERENCES assets(id)
 );
 
-CREATE TABLE IF NOT EXISTS imports (
-  id TEXT PRIMARY KEY,
-  user_id TEXT NOT NULL,
-  portfolio_id TEXT NOT NULL,
-  source_platform_id TEXT,
-  source_kind TEXT NOT NULL,
-  file_name TEXT,
-  file_hash TEXT,
-  status TEXT NOT NULL,
-  total_rows INTEGER DEFAULT 0,
-  valid_rows INTEGER DEFAULT 0,
-  invalid_rows INTEGER DEFAULT 0,
-  duplicate_rows INTEGER DEFAULT 0,
-  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  FOREIGN KEY (user_id) REFERENCES users(id),
-  FOREIGN KEY (portfolio_id) REFERENCES portfolios(id)
-);
-
-CREATE TABLE IF NOT EXISTS import_rows (
-  id TEXT PRIMARY KEY,
-  import_id TEXT NOT NULL,
-  row_number INTEGER NOT NULL,
-  status TEXT NOT NULL,
-  raw_row_json TEXT,
-  normalized_row_json TEXT,
-  validation_errors_json TEXT,
-  dedup_key TEXT,
-  conflict_summary_json TEXT,
-  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  FOREIGN KEY (import_id) REFERENCES imports(id)
-);
+CREATE INDEX IF NOT EXISTS idx_snapshot_positions_snapshot_id ON portfolio_snapshot_positions(snapshot_id);
+CREATE INDEX IF NOT EXISTS idx_snapshot_positions_asset_id ON portfolio_snapshot_positions(asset_id);
 
 CREATE TABLE IF NOT EXISTS portfolio_analyses (
   id TEXT PRIMARY KEY,
   portfolio_id TEXT NOT NULL,
-  snapshot_id TEXT,
-  scope TEXT NOT NULL,
-  score_value REAL,
+  snapshot_id TEXT NOT NULL,
+  score_value NUMERIC,
   score_status TEXT,
-  summary_text TEXT,
   primary_problem TEXT,
   primary_action TEXT,
-  recommendation_tag TEXT,
-  recommendation_target_type TEXT,
-  recommendation_target_id TEXT,
-  recommendation_title TEXT,
-  recommendation_body TEXT,
-  warnings_json TEXT,
-  ai_context_used_json TEXT,
-  raw_ai_response TEXT,
+  portfolio_decision TEXT,
+  action_plan_text TEXT,
+  summary_text TEXT,
+  messaging_json TEXT,
   generated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  FOREIGN KEY (portfolio_id) REFERENCES portfolios(id),
-  FOREIGN KEY (snapshot_id) REFERENCES portfolio_snapshots(id)
+  FOREIGN KEY (portfolio_id) REFERENCES portfolios(id) ON DELETE CASCADE,
+  FOREIGN KEY (snapshot_id) REFERENCES portfolio_snapshots(id) ON DELETE CASCADE
 );
+
+CREATE INDEX IF NOT EXISTS idx_portfolio_analyses_portfolio_id ON portfolio_analyses(portfolio_id);
+CREATE INDEX IF NOT EXISTS idx_portfolio_analyses_snapshot_id ON portfolio_analyses(snapshot_id);
+CREATE INDEX IF NOT EXISTS idx_portfolio_analyses_generated_at ON portfolio_analyses(generated_at);
 
 CREATE TABLE IF NOT EXISTS analysis_insights (
   id TEXT PRIMARY KEY,
   analysis_id TEXT NOT NULL,
-  insight_kind TEXT,
+  insight_type TEXT NOT NULL,
   title TEXT,
-  body TEXT,
-  severity TEXT,
-  sort_order INTEGER DEFAULT 0,
-  related_asset_id TEXT,
-  related_category_code TEXT,
+  message TEXT NOT NULL,
+  priority INTEGER,
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  FOREIGN KEY (analysis_id) REFERENCES portfolio_analyses(id)
+  FOREIGN KEY (analysis_id) REFERENCES portfolio_analyses(id) ON DELETE CASCADE
 );
+
+CREATE INDEX IF NOT EXISTS idx_analysis_insights_analysis_id ON analysis_insights(analysis_id);
+CREATE INDEX IF NOT EXISTS idx_analysis_insights_priority ON analysis_insights(priority);
 
 CREATE TABLE IF NOT EXISTS operational_events (
   id TEXT PRIMARY KEY,
+  user_id TEXT,
   portfolio_id TEXT,
   event_type TEXT NOT NULL,
   event_status TEXT NOT NULL,
   message TEXT,
   details_json TEXT,
   occurred_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  FOREIGN KEY (portfolio_id) REFERENCES portfolios(id)
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL,
+  FOREIGN KEY (portfolio_id) REFERENCES portfolios(id) ON DELETE SET NULL
 );
 
-CREATE INDEX IF NOT EXISTS idx_portfolio_positions_portfolio ON portfolio_positions(portfolio_id);
-CREATE INDEX IF NOT EXISTS idx_snapshots_portfolio ON portfolio_snapshots(portfolio_id, reference_date);
-CREATE INDEX IF NOT EXISTS idx_snapshot_positions_snapshot ON portfolio_snapshot_positions(snapshot_id);
-CREATE INDEX IF NOT EXISTS idx_import_rows_import ON import_rows(import_id, row_number);
-CREATE INDEX IF NOT EXISTS idx_portfolio_analyses_portfolio ON portfolio_analyses(portfolio_id, generated_at);
-CREATE INDEX IF NOT EXISTS idx_operational_events_portfolio ON operational_events(portfolio_id, occurred_at);
+CREATE INDEX IF NOT EXISTS idx_operational_events_user_id ON operational_events(user_id);
+CREATE INDEX IF NOT EXISTS idx_operational_events_portfolio_id ON operational_events(portfolio_id);
+CREATE INDEX IF NOT EXISTS idx_operational_events_occurred_at ON operational_events(occurred_at);

--- a/docs/10_target_architecture/README.md
+++ b/docs/10_target_architecture/README.md
@@ -3,6 +3,7 @@
 Esta pasta concentra a forma nova do projeto.
 
 Entram aqui:
+- decisao oficial de backend e fronteiras de transicao
 - stack
 - estrutura de pastas
 - serviços principais

--- a/docs/10_target_architecture/backend_oficial_e_fronteira_de_transicao.md
+++ b/docs/10_target_architecture/backend_oficial_e_fronteira_de_transicao.md
@@ -1,0 +1,149 @@
+# Backend oficial e fronteira de transicao
+
+## Decisao desta fase
+
+- stack oficial do produto novo: Cloudflare Workers + D1 + R2
+- runtime oficial da fase atual: `04_STARTER_BACKEND/esquilo_cloudflare_d1_starter`
+- destino estrutural oficial do backend: `services/api`
+- schema oficial do dominio: `database/d1/schema.sql`
+- contratos compartilhados oficiais: `packages/contracts/`
+- contrato HTTP oficial da fase: `services/api/openapi.yaml`
+- legado autorizado apenas como referencia: `docs/00_migration/*` e `OLD/*`
+
+## O que esta resolvido com esta decisao
+
+- o repositorio para de tratar `services/api`, `backend/` e `04_STARTER_BACKEND/` como tres candidatos iguais a backend oficial
+- o starter atual deixa de ser "codigo paralelo" e passa a ser a base executavel oficial da transicao
+- `services/api` deixa de ser lido como backend implementado hoje e passa a ser lido como casa final e contrato oficial
+- `database/d1/schema.sql` vira a fonte unica para decisao de modelo relacional
+- `packages/contracts` vira a casa oficial dos contratos compartilhados, mesmo antes de estar materializado como pacote TypeScript
+
+## Regra pratica por area
+
+### `services/api`
+
+Papel oficial:
+
+- casa final do backend executavel
+- casa oficial do contrato HTTP
+- referencia de rotas e fronteiras por dominio
+
+Regra:
+
+- nova rota ou mudanca relevante de API deve nascer alinhada aqui
+- enquanto o runtime nao for absorvido para esta pasta, a implementacao executavel continua no starter
+- nao criar outra arvore de backend fora desta trilha
+
+### `04_STARTER_BACKEND/esquilo_cloudflare_d1_starter`
+
+Papel oficial nesta fase:
+
+- base executavel real do backend novo
+- ambiente de transicao para Worker, rotas, services e repositories
+
+Regra:
+
+- toda implementacao nova de backend que precise rodar agora parte daqui
+- o starter nao e mais tratado como demo descartavel
+- o starter tambem nao passa a ser destino final de arquitetura
+- qualquer evolucao aqui precisa respeitar contrato oficial em `services/api` e schema oficial em `database/d1`
+
+### `database/d1`
+
+Papel oficial:
+
+- fonte unica de schema do dominio
+- casa de seeds e futuras migrations
+
+Regra:
+
+- decisao de tabela, coluna, relacao e indice nasce primeiro aqui
+- se o schema do starter divergir, prevalece `database/d1/schema.sql`
+- nao usar schema em `OLD/` como base de implementacao nova
+
+### `packages/contracts`
+
+Papel oficial:
+
+- casa de payloads compartilhados entre web, mobile e backend
+- casa do envelope HTTP e de estruturas comuns de resposta
+
+Regra:
+
+- contrato compartilhado novo deve ser definido aqui antes de se espalhar em tela ou rota
+- `src/types/contracts.ts` dentro do starter e adaptador temporario de runtime, nao fonte permanente de verdade
+
+### `backend/modules`
+
+Papel oficial:
+
+- area de regras isoladas e reaproveitaveis de dominio
+
+Regra:
+
+- nao receber novas rotas, novo router nem virar backend paralelo
+- so pode ser usado como modulo reaproveitavel ou candidato a absorcao futura
+
+## Dominios obrigatorios do MVP
+
+Os dominios abaixo precisam permanecer dentro da mesma arquitetura Cloudflare + D1:
+
+- `health` e envelope HTTP
+- `profile/context`
+- `dashboard/home`
+- `portfolio` e `holding detail`
+- `history/snapshots`
+- `imports start/preview/conflicts/detail/commit`
+- `analysis`
+- `operational events`
+
+Observacao:
+
+- `auth` existe hoje no starter como modulo operacional, mas nao deve comandar a arquitetura do MVP
+- a espinha do produto continua sendo consolidar, traduzir e orientar a carteira do usuario
+
+## Ordem oficial de implementacao
+
+Toda entrega nova deve seguir esta ordem:
+
+1. contrato compartilhado
+2. contrato HTTP
+3. schema e dado persistido
+4. repository
+5. service
+6. route
+7. consumo no front
+
+Regra:
+
+- nao inverter dado e contrato com UI
+- nao subir endpoint com stub estrutural se a base persistida ainda nao estiver coerente
+
+## Fronteira com o legado
+
+O legado fica limitado a tres papeis:
+
+- referencia historica de produto
+- apoio de migracao e mapeamento
+- comparacao de comportamento quando houver duvida
+
+O legado nao pode:
+
+- definir runtime
+- impor schema novo
+- virar dependencia operacional do backend novo
+
+## Riscos abertos que continuam explicitos
+
+- `database/d1/schema.sql` e `04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/schema.sql` divergem hoje
+- `services/api` ainda nao contem runtime executavel
+- `packages/contracts` ainda nao esta materializado como pacote TypeScript consumido pelo starter
+- existe OpenAPI concorrente fora da trilha oficial e ela nao deve orientar implementacao nova
+
+## Regra de execucao a partir desta issue
+
+- nao criar novo backend em pasta paralela
+- nao abrir nova fonte de schema
+- nao abrir novo contrato HTTP fora de `services/api`
+- nao marcar issue tecnica de API como pronta sem evidencia no starter executavel ou na futura absorcao em `services/api`
+- toda divergencia entre starter, schema e contrato oficial deve ser registrada, nao escondida

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ Este é o mapa principal da documentação do `Quebra_Nozes`.
 - `20_product/o_que_manter_do_legado.md`
 
 ### 3. Entender a forma técnica nova
+- `10_target_architecture/backend_oficial_e_fronteira_de_transicao.md`
 - `10_target_architecture/stack_e_pastas.md`
 - `10_target_architecture/api_e_dados.md`
 - `10_target_architecture/front_e_componentes.md`

--- a/docs/arquitetura/02_fontes_oficiais_e_conflitos.md
+++ b/docs/arquitetura/02_fontes_oficiais_e_conflitos.md
@@ -13,51 +13,40 @@
 ### Diagnostico oficial desta fase
 
 - `docs/90_diagnostico/*`
+- `docs/10_target_architecture/backend_oficial_e_fronteira_de_transicao.md`
 
-## Fontes concorrentes que exigem decisao
+## Decisoes fechadas nesta fase
 
 ### API
 
-Conflito:
-
-- `services/api/openapi.yaml`
-- `docs/api/swagger.yaml`
-
-Leitura:
-
-- a primeira fala a lingua de imports no produto novo
-- a segunda fala a lingua de score/goals/alerts
+- contrato HTTP oficial: `services/api/openapi.yaml`
+- `docs/api/swagger.yaml` nao orienta implementacao nova
+- `services/api` continua sendo a casa final da API, mesmo antes da absorcao do runtime
 
 ### Schema
 
-Conflito:
-
-- `database/d1/schema.sql`
-- `OLD/banco_legado/01_schema.sql`
-
-Leitura:
-
-- o schema em `database/d1` e menor e mais focado
-- `OLD/banco_legado/01_schema.sql` e mais amplo e inclui auth e outras estruturas
+- schema oficial do dominio: `database/d1/schema.sql`
+- `04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/schema.sql` fica subordinado a ele
+- `OLD/banco_legado/01_schema.sql` fica limitado a referencia historica
 
 ### Backend
 
-Conflito:
+- runtime oficial da fase atual: `04_STARTER_BACKEND/esquilo_cloudflare_d1_starter`
+- destino estrutural oficial: `services/api`
+- `backend/modules` fica restrito a modulo reutilizavel, nao a backend paralelo
 
-- `services/api`
-- `backend/modules`
-- `04_STARTER_BACKEND/esquilo_cloudflare_d1_starter`
+### Contratos compartilhados
 
-## Recomendacao desta fase
+- casa oficial: `packages/contracts`
+- `04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/src/types/contracts.ts` fica como adaptador temporario de runtime
 
-Tratar como oficial por evidencia de integracao:
+## Conflitos ainda abertos
 
-- backlog: GitHub
-- integracao: `main`
-- diagnostico: `docs/90_diagnostico`
-- backend mais vivo: `04_STARTER_BACKEND/esquilo_cloudflare_d1_starter`
+- o schema oficial e o schema do starter ainda divergem
+- `services/api` ainda nao contem runtime executavel
+- os contratos compartilhados ainda nao estao materializados como pacote TypeScript
 
-Mas manter a ressalva:
+## Regra desta fase
 
-- isso ainda nao resolve a decisao estrutural final
-- apenas descreve onde a implementacao real esta hoje
+- usar o contrato oficial, o schema oficial e o runtime oficial de transicao como linha unica de execucao
+- nao criar novas fontes concorrentes para API, banco ou backend

--- a/docs/arquitetura/README.md
+++ b/docs/arquitetura/README.md
@@ -14,7 +14,8 @@ Separar com clareza:
 
 ## Ordem de leitura
 
-1. `01_mapa_estrutural.md`
-2. `02_fontes_oficiais_e_conflitos.md`
-3. `03_reorganizacao_segura_da_arvore.md`
-4. `04_mapa_de_servicos_externos.md`
+1. `../10_target_architecture/backend_oficial_e_fronteira_de_transicao.md`
+2. `01_mapa_estrutural.md`
+3. `02_fontes_oficiais_e_conflitos.md`
+4. `03_reorganizacao_segura_da_arvore.md`
+5. `04_mapa_de_servicos_externos.md`

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -1,6 +1,12 @@
 # Contracts
 
-Esta pasta vai receber contratos compartilhados entre front e back.
+Esta pasta e a casa oficial dos contratos compartilhados entre front e back.
+
+Regra:
+
+- payload compartilhado novo nasce aqui
+- envelope HTTP e estruturas comuns tambem pertencem aqui
+- tipos dentro do starter sao adaptadores temporarios e nao substituem esta pasta como fonte oficial
 
 Exemplos:
 - schemas de payload

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -1,6 +1,22 @@
 # API
 
-Esta pasta vai receber o backend novo.
+Esta pasta e a casa final oficial do backend novo.
+
+Nesta fase, o runtime executavel ainda esta em:
+
+- `04_STARTER_BACKEND/esquilo_cloudflare_d1_starter`
+
+Papel desta pasta agora:
+
+- definir contrato HTTP oficial
+- registrar rotas e fronteiras por dominio
+- servir como destino estrutural da absorcao do starter
+
+Regra:
+
+- nao abrir API nova fora desta trilha
+- nao tratar esta pasta como "documentacao opcional"
+- toda mudanca relevante de rota deve ficar coerente com o runtime oficial de transicao
 
 Responsabilidades esperadas:
 - health


### PR DESCRIPTION
## Summary
- Locked the backend “source of truth” for this phase (runtime in `04_STARTER_BACKEND`, destination `services/api`, schema in `database/d1`, shared contracts in `packages/contracts`).
- Updated the official D1 schema to match the tables/columns actually used by the current Worker runtime (auth, onboarding context, imports, portfolio positions, analysis, operational events).
- Synced the starter `schema.sql` to mirror the official schema and avoid runtime/schema drift.

## Testing
- Not run (not requested)