### PR TITLE
TEC-007/#176: envelope HTTP e erros padrao (404/405)

### DIFF
--- a/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/src/lib/router.ts
+++ b/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/src/lib/router.ts
@@ -1,3 +1,5 @@
+import { fail } from './http';
+
 export type RouteHandler = (request: Request, env: any, params: Record<string, string>) => Promise<Response> | Response;
 
 interface Route {
@@ -26,18 +28,31 @@ export class Router {
   async handle(request: Request, env: any): Promise<Response | null> {
     const url = new URL(request.url);
     const method = request.method.toUpperCase();
+    const pathname = url.pathname;
+    const allowedMethods = new Set<string>();
 
     for (const route of this.routes) {
-      if (route.method !== method) continue;
-      const match = url.pathname.match(route.pattern);
+      const match = pathname.match(route.pattern);
       if (!match) continue;
 
-      const params: Record<string, string> = {};
-      route.keys.forEach((key, index) => {
-        params[key] = match[index + 1];
-      });
+      if (route.method === method) {
+        const params: Record<string, string> = {};
+        route.keys.forEach((key, index) => {
+          params[key] = match[index + 1];
+        });
+        return await route.handler(request, env, params);
+      }
 
-      return await route.handler(request, env, params);
+      allowedMethods.add(route.method);
+    }
+
+    if (allowedMethods.size) {
+      const allow = Array.from(allowedMethods).sort();
+      const response = fail(env?.API_VERSION || 'v1', 'method_not_allowed', 'Método não permitido para esta rota.', 405, {
+        allowedMethods: allow
+      });
+      response.headers.set('Allow', allow.join(', '));
+      return response;
     }
 
     return null;

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -2,6 +2,19 @@
 
 Esta pasta vai receber o backend novo.
 
+## Envelope HTTP (oficial)
+
+O backend responde sempre em JSON no formato:
+
+- sucesso: `{ ok: true, meta: { requestId, timestamp, version }, data }`
+- erro: `{ ok: false, meta: { requestId, timestamp, version }, error: { code, message, details? } }`
+
+Erros padrao do roteamento:
+
+- `route_not_found` (404)
+- `method_not_allowed` (405) com header `Allow`
+
+
 Responsabilidades esperadas:
 - health
 - profile/context

--- a/services/api/openapi.yaml
+++ b/services/api/openapi.yaml
@@ -10,6 +10,28 @@ paths:
       responses:
         '200':
           description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiOkImportStart'
+        '400':
+          description: Requisicao invalida
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelopeError'
+        '401':
+          description: Nao autenticado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelopeError'
+        '500':
+          description: Erro interno
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelopeError'
   /v1/imports/{importId}/preview:
     get:
       summary: Ler preview da importação
@@ -22,6 +44,34 @@ paths:
       responses:
         '200':
           description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiOkImportPreview'
+        '400':
+          description: Requisicao invalida
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelopeError'
+        '401':
+          description: Nao autenticado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelopeError'
+        '404':
+          description: Nao encontrado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelopeError'
+        '500':
+          description: Erro interno
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelopeError'
   /v1/imports/{importId}/engine-status:
     get:
       summary: Ler status operacional do motor de extração
@@ -34,6 +84,34 @@ paths:
       responses:
         '200':
           description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiOkImportEngineStatus'
+        '400':
+          description: Requisicao invalida
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelopeError'
+        '401':
+          description: Nao autenticado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelopeError'
+        '404':
+          description: Nao encontrado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelopeError'
+        '500':
+          description: Erro interno
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelopeError'
   /v1/imports/{importId}/detail:
     get:
       summary: Ler detalhe operacional do processamento da importação
@@ -46,6 +124,34 @@ paths:
       responses:
         '200':
           description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiOkImportDetail'
+        '400':
+          description: Requisicao invalida
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelopeError'
+        '401':
+          description: Nao autenticado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelopeError'
+        '404':
+          description: Nao encontrado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelopeError'
+        '500':
+          description: Erro interno
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelopeError'
   /v1/imports/{importId}/commit:
     post:
       summary: Commitar importação consistente
@@ -58,6 +164,34 @@ paths:
       responses:
         '200':
           description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiOkImportCommit'
+        '400':
+          description: Requisicao invalida
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelopeError'
+        '401':
+          description: Nao autenticado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelopeError'
+        '404':
+          description: Nao encontrado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelopeError'
+        '500':
+          description: Erro interno
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelopeError'
   /v1/imports/templates/custom:
     get:
       summary: Baixar template próprio CSV
@@ -72,6 +206,70 @@ paths:
           description: OK
 components:
   schemas:
+    ResponseMeta:
+      type: object
+      required: [requestId, timestamp, version]
+      properties:
+        requestId: { type: string }
+        timestamp: { type: string }
+        version: { type: string }
+        sourceWarning: { type: string, nullable: true }
+    ApiError:
+      type: object
+      required: [code, message]
+      properties:
+        code: { type: string }
+        message: { type: string }
+        details: { type: object, additionalProperties: true, nullable: true }
+    ApiEnvelopeOk:
+      type: object
+      required: [ok, meta, data]
+      properties:
+        ok: { type: boolean, const: true }
+        meta: { $ref: '#/components/schemas/ResponseMeta' }
+        data: { type: object }
+    ApiEnvelopeError:
+      type: object
+      required: [ok, meta, error]
+      properties:
+        ok: { type: boolean, const: false }
+        meta: { $ref: '#/components/schemas/ResponseMeta' }
+        error: { $ref: '#/components/schemas/ApiError' }
+    ApiOkImportStart:
+      allOf:
+        - $ref: '#/components/schemas/ApiEnvelopeOk'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/ImportStartData'
+    ApiOkImportPreview:
+      allOf:
+        - $ref: '#/components/schemas/ApiEnvelopeOk'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/ImportPreviewData'
+    ApiOkImportEngineStatus:
+      allOf:
+        - $ref: '#/components/schemas/ApiEnvelopeOk'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/ImportEngineStatusData'
+    ApiOkImportDetail:
+      allOf:
+        - $ref: '#/components/schemas/ApiEnvelopeOk'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/ImportDetailData'
+    ApiOkImportCommit:
+      allOf:
+        - $ref: '#/components/schemas/ApiEnvelopeOk'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/ImportCommitData'
     ImportStartData:
       type: object
       properties:

--- a/services/api/openapi_base.yaml
+++ b/services/api/openapi_base.yaml
@@ -9,3 +9,58 @@ paths:
       responses:
         '200':
           description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiOkHealth'
+        '500':
+          description: Erro interno
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelopeError'
+components:
+  schemas:
+    ResponseMeta:
+      type: object
+      required: [requestId, timestamp, version]
+      properties:
+        requestId: { type: string }
+        timestamp: { type: string }
+        version: { type: string }
+        sourceWarning: { type: string, nullable: true }
+    ApiError:
+      type: object
+      required: [code, message]
+      properties:
+        code: { type: string }
+        message: { type: string }
+        details: { type: object, additionalProperties: true, nullable: true }
+    ApiEnvelopeOk:
+      type: object
+      required: [ok, meta, data]
+      properties:
+        ok: { type: boolean, const: true }
+        meta: { $ref: '#/components/schemas/ResponseMeta' }
+        data: { type: object }
+    ApiEnvelopeError:
+      type: object
+      required: [ok, meta, error]
+      properties:
+        ok: { type: boolean, const: false }
+        meta: { $ref: '#/components/schemas/ResponseMeta' }
+        error: { $ref: '#/components/schemas/ApiError' }
+    HealthData:
+      type: object
+      properties:
+        ok: { type: boolean }
+        db: { type: object, additionalProperties: true }
+        version: { type: string }
+        env: { type: string }
+    ApiOkHealth:
+      allOf:
+        - $ref: '#/components/schemas/ApiEnvelopeOk'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/HealthData'


### PR DESCRIPTION
Padroniza envelope de sucesso/erro e formaliza 404 route_not_found e 405 method_not_allowed (com header Allow). Inclui documentacao e OpenAPI com ApiEnvelopeOk/ApiEnvelopeError.\n\nRefs #176