### PR TITLE
E2E-023/#242: hardening de acesso entre usuarios (imports)

### DIFF
--- a/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/src/lib/import_conflicts_service.ts
+++ b/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/src/lib/import_conflicts_service.ts
@@ -1,7 +1,7 @@
 import type { Env } from '../types/env';
 import { ok, fail } from './http';
 import { hashToken } from './auth_crypto';
-import { findImportSessionStateByTokenHash, findImportById, findImportRows } from '../repositories/import_repository';
+import { findImportSessionStateByTokenHash, findOwnedImportById, findImportRows } from '../repositories/import_repository';
 
 const AUTH_COOKIE_NAME = 'esquilo_session';
 
@@ -9,8 +9,8 @@ export async function getImportConflictsData(request: Request, env: Env, params:
   const session = await requireImportSession(request, env);
   if (session instanceof Response) return session;
 
-  const importRecord = await findImportById(env, params.importId);
-  if (!importRecord || importRecord.user_id !== session.userId) {
+  const importRecord = await findOwnedImportById(env, session.userId, params.importId);
+  if (!importRecord) {
     return fail(env.API_VERSION, 'import_not_found', 'Importação não encontrada.', 404);
   }
 

--- a/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/src/lib/import_detail_service.ts
+++ b/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/src/lib/import_detail_service.ts
@@ -1,7 +1,7 @@
 import type { Env } from '../types/env';
 import { ok, fail } from './http';
 import { hashToken } from './auth_crypto';
-import { findImportSessionStateByTokenHash, findImportById, findImportRows } from '../repositories/import_repository';
+import { findImportSessionStateByTokenHash, findOwnedImportById, findImportRows, findLatestSnapshotByOwnedImportId } from '../repositories/import_repository';
 import { buildImportOperationalFacts, deriveImportEngineStatus } from './import_operational_helpers';
 
 const AUTH_COOKIE_NAME = 'esquilo_session';
@@ -10,13 +10,13 @@ export async function getImportDetailData(request: Request, env: Env, params: Re
   const session = await requireImportSession(request, env);
   if (session instanceof Response) return session;
 
-  const importRecord = await findImportById(env, params.importId);
-  if (!importRecord || importRecord.user_id !== session.userId) {
+  const importRecord = await findOwnedImportById(env, session.userId, params.importId);
+  if (!importRecord) {
     return fail(env.API_VERSION, 'import_not_found', 'Importação não encontrada.', 404);
   }
 
   const rows = await findImportRows(env, params.importId);
-  const snapshot = await findSnapshotByImportId(env, params.importId);
+  const snapshot = await findLatestSnapshotByOwnedImportId(env, session.userId, params.importId);
   const facts = buildImportOperationalFacts(rows, importRecord.origin);
   const engineStatus = deriveImportEngineStatus(importRecord.status, facts);
   const detailedRows = rows.map((row) => mapImportDetailRow(row));
@@ -93,23 +93,6 @@ async function requireImportSession(request: Request, env: Env): Promise<{ userI
   if (!session.hasContext) return ok(env.API_VERSION, { screenState: 'redirect_onboarding', redirectTo: '/onboarding' });
   if (!session.portfolioId) return fail(env.API_VERSION, 'portfolio_not_found', 'Carteira principal não encontrada.', 404);
   return { userId: session.userId, portfolioId: session.portfolioId };
-}
-
-async function findSnapshotByImportId(env: Env, importId: string) {
-  return await env.DB.prepare(
-    `SELECT id, reference_date, total_equity, total_invested, total_profit_loss, total_profit_loss_pct
-       FROM portfolio_snapshots
-      WHERE import_id = ?
-      ORDER BY created_at DESC
-      LIMIT 1`
-  ).bind(importId).first<{
-    id: string;
-    reference_date: string;
-    total_equity: number | null;
-    total_invested: number | null;
-    total_profit_loss: number | null;
-    total_profit_loss_pct: number | null;
-  }>();
 }
 
 function mapImportDetailRow(row: {

--- a/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/src/lib/import_engine_status_service.ts
+++ b/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/src/lib/import_engine_status_service.ts
@@ -1,7 +1,7 @@
 import type { Env } from '../types/env';
 import { ok, fail } from './http';
 import { hashToken } from './auth_crypto';
-import { findImportSessionStateByTokenHash, findImportById, findImportRows } from '../repositories/import_repository';
+import { findImportSessionStateByTokenHash, findOwnedImportById, findImportRows } from '../repositories/import_repository';
 import { buildImportOperationalFacts, deriveImportEngineStatus } from './import_operational_helpers';
 
 const AUTH_COOKIE_NAME = 'esquilo_session';
@@ -10,8 +10,8 @@ export async function getImportEngineStatusData(request: Request, env: Env, para
   const session = await requireImportSession(request, env);
   if (session instanceof Response) return session;
 
-  const importRecord = await findImportById(env, params.importId);
-  if (!importRecord || importRecord.user_id !== session.userId) {
+  const importRecord = await findOwnedImportById(env, session.userId, params.importId);
+  if (!importRecord) {
     return fail(env.API_VERSION, 'import_not_found', 'Importação não encontrada.', 404);
   }
 

--- a/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/src/lib/import_service.ts
+++ b/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/src/lib/import_service.ts
@@ -1,7 +1,7 @@
 import type { Env } from '../types/env';
 import { ok, fail, readJson } from './http';
 import { buildEntityId, hashToken } from './auth_crypto';
-import { findImportSessionStateByTokenHash, createImportRecord, updateImportRecord, replaceImportRows, findImportById, findImportRows, findManualDuplicateCandidates, findAssetTypeByCode, findAssetByNormalizedNameOrCode, createAsset, createPortfolioPosition, createPortfolioSnapshot, createSnapshotPosition } from '../repositories/import_repository';
+import { findImportSessionStateByTokenHash, createImportRecord, updateImportRecord, replaceImportRows, findOwnedImportById, findImportRows, findManualDuplicateCandidates, findAssetTypeByCode, findAssetByNormalizedNameOrCode, createAsset, createPortfolioPosition, createPortfolioSnapshot, createSnapshotPosition } from '../repositories/import_repository';
 
 const AUTH_COOKIE_NAME = 'esquilo_session';
 const ORIGIN_MANUAL_ENTRY = 'MANUAL_ENTRY';
@@ -289,7 +289,7 @@ async function requireImportSession(request: Request, env: Env): Promise<{ userI
   const tokenHash = await hashToken(token); const session = await findImportSessionStateByTokenHash(env, tokenHash); if (!session) return fail(env.API_VERSION, 'unauthorized', 'Sessão inválida.', 401); if (!session.hasContext) return ok(env.API_VERSION, { screenState: 'redirect_onboarding', redirectTo: '/onboarding' }); if (!session.portfolioId) return fail(env.API_VERSION, 'portfolio_not_found', 'Carteira principal não encontrada.', 404); return { userId: session.userId, portfolioId: session.portfolioId };
 }
 
-async function findOwnedImport(env: Env, userId: string, importId: string) { const importRecord = await findImportById(env, importId); if (!importRecord || importRecord.user_id !== userId) return fail(env.API_VERSION, 'import_not_found', 'Importação não encontrada.', 404); return importRecord; }
+async function findOwnedImport(env: Env, userId: string, importId: string) { const importRecord = await findOwnedImportById(env, userId, importId); if (!importRecord) return fail(env.API_VERSION, 'import_not_found', 'Importação não encontrada.', 404); return importRecord; }
 
 async function buildPreviewRows(env: Env, portfolioId: string, entries: Array<{ id: string; rowNumber: number; sourcePayloadJson: string; normalizedPayloadJson: string; parsed: ReturnType<typeof normalizeManualEntry>; fieldSources: Record<string, unknown>; fieldConfidences: Record<string, unknown>; warnings: string[] }>, importable: boolean) {
   const rows: Array<{ id: string; rowNumber: number; sourcePayloadJson: string; normalizedPayloadJson: string; resolutionStatus: string; errorMessage: string | null }> = [];

--- a/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/src/repositories/import_repository.ts
+++ b/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/src/repositories/import_repository.ts
@@ -12,10 +12,16 @@ export interface ImportRecordRow {
   portfolio_id: string | null;
   status: string;
   origin: string;
+  file_name?: string | null;
+  mime_type?: string | null;
   total_rows: number;
   valid_rows: number;
   invalid_rows: number;
   duplicate_rows: number;
+  created_at?: string;
+  started_at?: string;
+  updated_at?: string | null;
+  finished_at?: string | null;
 }
 
 export interface ImportPreviewRow {
@@ -135,11 +141,74 @@ export async function replaceImportRows(env: Env, importId: string, rows: Array<
 
 export async function findImportById(env: Env, importId: string): Promise<ImportRecordRow | null> {
   return await env.DB.prepare(
-    `SELECT id, user_id, portfolio_id, status, origin, total_rows, valid_rows, invalid_rows, duplicate_rows
+    `SELECT id,
+            user_id,
+            portfolio_id,
+            status,
+            origin,
+            file_name,
+            mime_type,
+            total_rows,
+            valid_rows,
+            invalid_rows,
+            duplicate_rows,
+            created_at,
+            started_at,
+            updated_at,
+            finished_at
      FROM imports
      WHERE id = ?
      LIMIT 1`
   ).bind(importId).first<ImportRecordRow>();
+}
+
+export async function findOwnedImportById(env: Env, userId: string, importId: string): Promise<ImportRecordRow | null> {
+  return await env.DB.prepare(
+    `SELECT id,
+            user_id,
+            portfolio_id,
+            status,
+            origin,
+            file_name,
+            mime_type,
+            total_rows,
+            valid_rows,
+            invalid_rows,
+            duplicate_rows,
+            created_at,
+            started_at,
+            updated_at,
+            finished_at
+     FROM imports
+     WHERE id = ?
+       AND user_id = ?
+     LIMIT 1`
+  ).bind(importId, userId).first<ImportRecordRow>();
+}
+
+export async function findLatestSnapshotByOwnedImportId(env: Env, userId: string, importId: string) {
+  return await env.DB.prepare(
+    `SELECT ps.id,
+            ps.reference_date,
+            ps.total_equity,
+            ps.total_invested,
+            ps.total_profit_loss,
+            ps.total_profit_loss_pct
+     FROM portfolio_snapshots ps
+     JOIN imports i
+       ON i.id = ps.import_id
+      AND i.user_id = ?
+     WHERE ps.import_id = ?
+     ORDER BY ps.created_at DESC
+     LIMIT 1`
+  ).bind(userId, importId).first<{
+    id: string;
+    reference_date: string;
+    total_equity: number | null;
+    total_invested: number | null;
+    total_profit_loss: number | null;
+    total_profit_loss_pct: number | null;
+  }>();
 }
 
 export async function findImportRows(env: Env, importId: string): Promise<ImportPreviewRow[]> {


### PR DESCRIPTION
Objetivo\n- Garantir separacao minima de dados entre usuarios, especialmente em rotas com :importId.\n\nO que mudou\n- Repositorio D1 passa a expor queries com ownership (user_id) para import e snapshot por import.\n- Services de imports (detail/conflicts/engine-status e fluxo principal) passam a usar essas queries, reduzindo risco de vazamento por esquecimento de checagem manual.\n\nNotas\n- Nao valida E2E real aqui (sem Node/wrangler no ambiente). A evidencia e por auditoria + enforce no nivel de query.