### PR TITLE
TEC-005/#174: seeds iniciais alinhadas ao schema

### DIFF
--- a/database/seeds/README.md
+++ b/database/seeds/README.md
@@ -8,3 +8,33 @@ Exemplos:
 - sem carteira
 - importação com conflito
 - fundos e previdência
+
+## Como aplicar (local)
+
+Ordem recomendada:
+
+1. aplicar schema oficial: `database/d1/schema.sql`
+2. aplicar seed base: `database/seeds/seed_base.sql`
+3. aplicar cenarios extras (opcional):
+   - `database/seeds/seed_import_scenario.sql`
+   - `database/seeds/seed_onboarding_no_context.sql`
+
+## Credenciais seed
+
+- senha seed (para login): `Senha123!`
+- usuarios seed (CPF / email):
+  - balanced: `11122233344` / `balanced@example.com`
+  - concentrated: `55566677788` / `concentrated@example.com`
+  - empty: `99988877766` / `empty@example.com`
+  - import: `12345678901` / `import@example.com`
+  - onboarding (sem contexto): `10101010101` / `onboarding@example.com`
+
+## Acesso rapido via cookie (sem login)
+
+As rotas do backend exigem cookie `esquilo_session`. Para facilitar teste local, as seeds criam sessoes com tokens conhecidos.
+
+- `Cookie: esquilo_session=seed_balanced_token_v1`
+- `Cookie: esquilo_session=seed_concentrated_token_v1`
+- `Cookie: esquilo_session=seed_empty_token_v1`
+- `Cookie: esquilo_session=seed_import_token_v1`
+- `Cookie: esquilo_session=seed_onboarding_token_v1`

--- a/database/seeds/seed_base.sql
+++ b/database/seeds/seed_base.sql
@@ -1,99 +1,207 @@
--- Seed base inicial do Quebra_Nozes
+-- Seeds base do Quebra_Nozes (MVP)
+-- Alinhado ao schema oficial: `database/d1/schema.sql`
 
-INSERT INTO users (id, display_name, email)
-VALUES ('user_demo', 'Usuário Demo', 'demo@example.com');
+-- Credenciais seed (para login):
+-- senha: `Senha123!`
+-- tokens seed de sessao (para cookie `esquilo_session`):
+-- - balanced: `seed_balanced_token_v1`
+-- - concentrated: `seed_concentrated_token_v1`
+-- - empty: `seed_empty_token_v1`
+-- - import: `seed_import_token_v1`
+
+-- Referencias (reutilizaveis)
+INSERT INTO platforms (id, code, name) VALUES
+('plt_xp', 'xp', 'XP Investimentos'),
+('plt_ion', 'ion', 'Ion Itau');
+
+INSERT INTO asset_types (id, code, name) VALUES
+('aty_stock', 'STOCK', 'Acoes'),
+('aty_fund', 'FUND', 'Fundos'),
+('aty_pension', 'PENSION', 'Previdencia');
+
+INSERT INTO assets (id, asset_type_id, code, name, normalized_name) VALUES
+('ast_itsa4', 'aty_stock', 'ITSA4', 'Itausa', 'itausa'),
+('ast_cmin3', 'aty_stock', 'CMIN3', 'CSN Mineracao', 'csn mineracao'),
+('ast_fund_mm', 'aty_fund', NULL, 'Fundo Multimercado Demo', 'fundo multimercado demo'),
+('ast_prev', 'aty_pension', NULL, 'Previdencia Demo', 'previdencia demo');
+
+-- Cenario 1: carteira equilibrada (pronta)
+INSERT INTO users (id, cpf, email, password_hash, display_name, status) VALUES
+('usr_seed_balanced', '11122233344', 'balanced@example.com', 'pbkdf2_sha256$210000$AQIDBAUGBwgJCgsMDQ4PEA$jbWPdVpAx7pu8ZCx0wY0j1VsKVnFfedYNCZR6r-R19Y', 'Usuario Balanced', 'ACTIVE');
+
+INSERT INTO auth_sessions (id, user_id, session_token_hash, remember_device, expires_at, created_at, last_seen_at) VALUES
+('ses_seed_balanced', 'usr_seed_balanced', '9fcb045ffe3cdb6c05a05d4d4d7be11d531a017bd5082d886096a9d8a1ec43aa', 1, '2099-01-01T00:00:00.000Z', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+INSERT INTO portfolios (id, user_id, name, is_primary, status) VALUES
+('pfl_seed_balanced', 'usr_seed_balanced', 'Carteira Principal', 1, 'active');
 
 INSERT INTO user_financial_context (
-  user_id,
-  financial_goal,
-  monthly_income_range,
-  monthly_investment_target,
-  available_to_invest,
-  risk_profile,
-  investment_horizon,
-  platforms_used_json,
-  display_preferences_json
-)
-VALUES (
-  'user_demo',
+  id, user_id, financial_goal, monthly_income_range, monthly_investment_target, available_to_invest,
+  risk_profile, risk_profile_self_declared, risk_profile_quiz_result, risk_profile_effective,
+  investment_horizon, platforms_used_json, display_preferences_json, onboarding_step
+) VALUES (
+  'ctx_seed_balanced',
+  'usr_seed_balanced',
   'equilibrar e crescer',
   '10k-15k',
   1000,
   500,
   'moderado',
+  'moderado',
+  'moderado',
+  'moderado',
   'longo_prazo',
   '["xp","ion"]',
-  '{"ghostMode":false}'
+  '{"ghostMode":false}',
+  'done'
 );
-
-INSERT INTO platforms (id, code, name) VALUES
-('platform_xp', 'xp', 'XP Investimentos'),
-('platform_ion', 'ion', 'Íon Itaú');
-
-INSERT INTO asset_types (id, code, name) VALUES
-('type_stock', 'STOCK', 'Ações'),
-('type_fund', 'FUND', 'Fundos'),
-('type_pension', 'PENSION', 'Previdência');
-
-INSERT INTO assets (id, asset_type_id, code, name) VALUES
-('asset_itsa4', 'type_stock', 'ITSA4', 'Itaúsa'),
-('asset_cmin3', 'type_stock', 'CMIN3', 'CSN Mineração'),
-('asset_fund_demo', 'type_fund', NULL, 'Fundo Multimercado Demo'),
-('asset_pension_demo', 'type_pension', NULL, 'Previdência Demo');
-
-INSERT INTO portfolios (id, user_id, name, base_currency, status)
-VALUES ('portfolio_main', 'user_demo', 'Carteira Principal', 'BRL', 'active');
 
 INSERT INTO portfolio_positions (
   id, portfolio_id, asset_id, platform_id, source_kind, status,
-  quantity, average_price, current_price, invested_amount, current_value, reference_date
+  quantity, average_price, current_price, invested_amount, current_amount, category_label, notes
 ) VALUES
-('pos_1', 'portfolio_main', 'asset_itsa4', 'platform_xp', 'manual', 'active', 27, 13.84, 14.52, 373.68, 392.04, '2026-03-31'),
-('pos_2', 'portfolio_main', 'asset_cmin3', 'platform_xp', 'manual', 'active', 62, 5.95, 5.40, 368.90, 334.80, '2026-03-31'),
-('pos_3', 'portfolio_main', 'asset_fund_demo', 'platform_xp', 'manual', 'active', 1, 5000.00, 5200.00, 5000.00, 5200.00, '2026-03-31'),
-('pos_4', 'portfolio_main', 'asset_pension_demo', 'platform_ion', 'manual', 'active', 1, 15000.00, 15350.00, 15000.00, 15350.00, '2026-03-31');
+('pos_bal_1', 'pfl_seed_balanced', 'ast_itsa4', 'plt_xp', 'manual', 'active', 27, 13.84, 14.52, 373.68, 392.04, 'Acoes', 'Base de acoes para leitura'),
+('pos_bal_2', 'pfl_seed_balanced', 'ast_cmin3', 'plt_xp', 'manual', 'active', 62, 5.95, 5.40, 368.90, 334.80, 'Acoes', 'Exemplo de queda para stress'),
+('pos_bal_3', 'pfl_seed_balanced', 'ast_fund_mm', 'plt_xp', 'manual', 'active', 1, 5000.00, 5200.00, 5000.00, 5200.00, 'Fundos', 'Multimercado'),
+('pos_bal_4', 'pfl_seed_balanced', 'ast_prev', 'plt_ion', 'manual', 'active', 1, 15000.00, 15350.00, 15000.00, 15350.00, 'Previdencia', 'Concentracao controlada');
 
 INSERT INTO portfolio_snapshots (
-  id, portfolio_id, reference_date, total_equity, total_invested, total_profit_loss, total_profit_loss_pct, source_kind
+  id, portfolio_id, import_id, reference_date, total_equity, total_invested, total_profit_loss, total_profit_loss_pct
 ) VALUES
-('snap_1', 'portfolio_main', '2026-03-31', 21276.84, 20742.58, 534.26, 2.58, 'manual');
+('snp_bal_1', 'pfl_seed_balanced', NULL, '2026-03-31', 21276.84, 20742.58, 534.26, 2.58);
 
-INSERT INTO portfolio_snapshot_positions (
-  id, snapshot_id, asset_id, quantity, average_price, current_price, invested_amount, current_value, performance_pct, allocation_pct
-) VALUES
-('snap_pos_1', 'snap_1', 'asset_itsa4', 27, 13.84, 14.52, 373.68, 392.04, 4.92, 1.84),
-('snap_pos_2', 'snap_1', 'asset_cmin3', 62, 5.95, 5.40, 368.90, 334.80, -9.24, 1.57),
-('snap_pos_3', 'snap_1', 'asset_fund_demo', 1, 5000.00, 5200.00, 5000.00, 5200.00, 4.00, 24.44),
-('snap_pos_4', 'snap_1', 'asset_pension_demo', 1, 15000.00, 15350.00, 15000.00, 15350.00, 2.33, 72.15);
+INSERT INTO portfolio_snapshot_positions (id, snapshot_id, asset_id, quantity, unit_price, current_value) VALUES
+('snp_bal_1_itsa4', 'snp_bal_1', 'ast_itsa4', 27, 14.52, 392.04),
+('snp_bal_1_cmin3', 'snp_bal_1', 'ast_cmin3', 62, 5.40, 334.80),
+('snp_bal_1_mm', 'snp_bal_1', 'ast_fund_mm', 1, 5200.00, 5200.00),
+('snp_bal_1_prev', 'snp_bal_1', 'ast_prev', 1, 15350.00, 15350.00);
 
 INSERT INTO portfolio_analyses (
-  id, portfolio_id, snapshot_id, scope, score_value, score_status, summary_text,
-  primary_problem, primary_action, recommendation_tag, recommendation_target_type,
-  recommendation_target_id, recommendation_title, recommendation_body
+  id, portfolio_id, snapshot_id, score_value, score_status, primary_problem, primary_action,
+  portfolio_decision, action_plan_text, summary_text, messaging_json, generated_at
 ) VALUES (
-  'analysis_1',
-  'portfolio_main',
-  'snap_1',
-  'portfolio',
+  'anl_bal_1',
+  'pfl_seed_balanced',
+  'snp_bal_1',
   72,
   'atencao_moderada',
-  'Sua carteira está funcional, mas concentrada demais em previdência.',
-  'O principal ponto de atenção hoje é a concentração excessiva em um único bloco.',
-  'Diluir concentração aos poucos.',
-  'REDUCE_CONCENTRATION',
-  'category',
-  'PENSION',
-  'Diluir concentração aos poucos',
-  'Use novos aportes para abrir mais equilíbrio fora da previdência.'
+  'Concentracao relativamente alta em previdencia.',
+  'Diluir concentracao aos poucos.',
+  'Priorizar aportes fora da previdencia ate reduzir concentracao.',
+  '1) Definir percentual alvo por classe\n2) Direcionar novos aportes para a classe sub-representada\n3) Reavaliar em 30 dias',
+  'Carteira funcional, mas com concentracao relevante.',
+  '{"tone":"direto","headline":"Concentracao em Previdencia"}',
+  CURRENT_TIMESTAMP
 );
 
-INSERT INTO analysis_insights (
-  id, analysis_id, insight_kind, title, body, severity, sort_order, related_category_code
-) VALUES
-('insight_1', 'analysis_1', 'concentration', 'Previdência pesa demais', 'Sua proteção virou bloco grande demais dentro da carteira.', 'warning', 1, 'PENSION'),
-('insight_2', 'analysis_1', 'balance', 'Ações ainda têm pouco peso', 'Há espaço para crescimento ganhar mais relevância ao longo do tempo.', 'info', 2, 'STOCK');
+INSERT INTO analysis_insights (id, analysis_id, insight_type, title, message, priority) VALUES
+('ins_bal_1', 'anl_bal_1', 'concentration', 'Previdencia pesa demais', 'Sua previdencia virou o maior bloco da carteira.', 1),
+('ins_bal_2', 'anl_bal_1', 'balance', 'Acoes ainda tem pouco peso', 'Ha espaco para crescimento ganhar mais relevancia aos poucos.', 2);
 
-INSERT INTO operational_events (
-  id, portfolio_id, event_type, event_status, message
+INSERT INTO operational_events (id, user_id, portfolio_id, event_type, event_status, message) VALUES
+('evt_bal_1', 'usr_seed_balanced', 'pfl_seed_balanced', 'seed_created', 'ok', 'Cenario balanced criado.');
+
+-- Cenario 2: carteira concentrada (edge case de concentracao)
+INSERT INTO users (id, cpf, email, password_hash, display_name, status) VALUES
+('usr_seed_concentrated', '55566677788', 'concentrated@example.com', 'pbkdf2_sha256$210000$__79_Pv6-fj39vX08_Lx8A$b36UdHYUtbu0t3p_Gb2o-X9cmfcPy1rrY9bReX3waSM', 'Usuario Concentrated', 'ACTIVE');
+
+INSERT INTO auth_sessions (id, user_id, session_token_hash, remember_device, expires_at, created_at, last_seen_at) VALUES
+('ses_seed_concentrated', 'usr_seed_concentrated', '5ba0a14d6543bd8c93a5197b64b943ff76e016f0c2b6e77c3d3365e91338508a', 1, '2099-01-01T00:00:00.000Z', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+INSERT INTO portfolios (id, user_id, name, is_primary, status) VALUES
+('pfl_seed_concentrated', 'usr_seed_concentrated', 'Carteira Principal', 1, 'active');
+
+INSERT INTO user_financial_context (
+  id, user_id, financial_goal, monthly_income_range, monthly_investment_target, available_to_invest,
+  risk_profile, risk_profile_self_declared, risk_profile_quiz_result, risk_profile_effective,
+  investment_horizon, platforms_used_json, display_preferences_json, onboarding_step
+) VALUES (
+  'ctx_seed_concentrated',
+  'usr_seed_concentrated',
+  'crescer rapido',
+  '15k-25k',
+  3000,
+  1500,
+  'arrojado',
+  'arrojado',
+  'arrojado',
+  'arrojado',
+  'longo_prazo',
+  '["xp"]',
+  '{"ghostMode":false}',
+  'done'
+);
+
+INSERT INTO portfolio_positions (
+  id, portfolio_id, asset_id, platform_id, source_kind, status,
+  quantity, average_price, current_price, invested_amount, current_amount, category_label, stop_loss, target_price, profitability, notes
 ) VALUES
-('event_1', 'portfolio_main', 'seed_created', 'ok', 'Carteira demo criada com snapshot inicial.');
+('pos_con_1', 'pfl_seed_concentrated', 'ast_prev', 'plt_ion', 'manual', 'active', 1, 50000.00, 51000.00, 50000.00, 51000.00, 'Previdencia', 45000.00, 60000.00, 2.00, 'Bloco dominante'),
+('pos_con_2', 'pfl_seed_concentrated', 'ast_itsa4', 'plt_xp', 'manual', 'active', 10, 13.00, 14.50, 130.00, 145.00, 'Acoes', NULL, NULL, 11.54, 'Posicao pequena');
+
+INSERT INTO portfolio_snapshots (
+  id, portfolio_id, import_id, reference_date, total_equity, total_invested, total_profit_loss, total_profit_loss_pct
+) VALUES
+('snp_con_1', 'pfl_seed_concentrated', NULL, '2026-03-31', 51145.00, 50130.00, 1015.00, 2.02);
+
+INSERT INTO portfolio_snapshot_positions (id, snapshot_id, asset_id, quantity, unit_price, current_value) VALUES
+('snp_con_1_prev', 'snp_con_1', 'ast_prev', 1, 51000.00, 51000.00),
+('snp_con_1_itsa4', 'snp_con_1', 'ast_itsa4', 10, 14.50, 145.00);
+
+INSERT INTO portfolio_analyses (
+  id, portfolio_id, snapshot_id, score_value, score_status, primary_problem, primary_action,
+  portfolio_decision, action_plan_text, summary_text, messaging_json, generated_at
+) VALUES (
+  'anl_con_1',
+  'pfl_seed_concentrated',
+  'snp_con_1',
+  48,
+  'risco_alto',
+  'Concentracao extrema em um unico bloco.',
+  'Parar de reforcar o bloco dominante e diversificar.',
+  'Conter novos aportes no bloco dominante.',
+  '1) Definir teto por classe\n2) Redirecionar aportes\n3) Revisar risco',
+  'Carteira com risco concentrado alto.',
+  '{"tone":"alerta","headline":"Concentracao extrema"}',
+  CURRENT_TIMESTAMP
+);
+
+INSERT INTO analysis_insights (id, analysis_id, insight_type, title, message, priority) VALUES
+('ins_con_1', 'anl_con_1', 'concentration', 'Um bloco domina a carteira', 'A maior parte do patrimonio esta em Previdencia.', 1);
+
+INSERT INTO operational_events (id, user_id, portfolio_id, event_type, event_status, message) VALUES
+('evt_con_1', 'usr_seed_concentrated', 'pfl_seed_concentrated', 'seed_created', 'ok', 'Cenario concentrated criado.');
+
+-- Cenario 3: carteira vazia (com contexto) para testar estados "empty"
+INSERT INTO users (id, cpf, email, password_hash, display_name, status) VALUES
+('usr_seed_empty', '99988877766', 'empty@example.com', 'pbkdf2_sha256$210000$AAcOFRwjKjE4P0ZNVFtiaQ$RFW9BH_jV6E5_y_BqndRkjeIib3-IbqHpeSEZcZtgs4', 'Usuario Empty', 'ACTIVE');
+
+INSERT INTO auth_sessions (id, user_id, session_token_hash, remember_device, expires_at, created_at, last_seen_at) VALUES
+('ses_seed_empty', 'usr_seed_empty', '575a474bedc88fcd8e64833f61af36d2587cf599698e308d89fb094fe0343c64', 1, '2099-01-01T00:00:00.000Z', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+INSERT INTO portfolios (id, user_id, name, is_primary, status) VALUES
+('pfl_seed_empty', 'usr_seed_empty', 'Carteira Principal', 1, 'active');
+
+INSERT INTO user_financial_context (
+  id, user_id, financial_goal, monthly_income_range, monthly_investment_target, available_to_invest,
+  risk_profile, risk_profile_self_declared, risk_profile_quiz_result, risk_profile_effective,
+  investment_horizon, platforms_used_json, display_preferences_json, onboarding_step
+) VALUES (
+  'ctx_seed_empty',
+  'usr_seed_empty',
+  'comecar a investir',
+  '3k-5k',
+  300,
+  200,
+  'conservador',
+  'conservador',
+  'conservador',
+  'conservador',
+  'medio_prazo',
+  '[]',
+  '{"ghostMode":false}',
+  'done'
+);
+
+INSERT INTO operational_events (id, user_id, portfolio_id, event_type, event_status, message) VALUES
+('evt_empty_1', 'usr_seed_empty', 'pfl_seed_empty', 'seed_created', 'ok', 'Cenario empty criado.');

--- a/database/seeds/seed_import_scenario.sql
+++ b/database/seeds/seed_import_scenario.sql
@@ -1,0 +1,131 @@
+-- Cenario extra: importacao com conflitos / erros / baixa confianca
+-- Alinhado ao schema oficial: `database/d1/schema.sql`
+
+INSERT INTO users (id, cpf, email, password_hash, display_name, status) VALUES
+('usr_seed_import', '12345678901', 'import@example.com', 'pbkdf2_sha256$210000$CxglMj9MWWZzgI2ap7TBzg$MUW8bazRDO-EHwo7MZykt7Uyp5P7vLffjUwWuOOEqX8', 'Usuario Import', 'ACTIVE');
+
+INSERT INTO auth_sessions (id, user_id, session_token_hash, remember_device, expires_at, created_at, last_seen_at) VALUES
+('ses_seed_import', 'usr_seed_import', '2dfb2778ddf7a737890cd1be489f6a6be42f7a62aff456763e2a1982726a0542', 1, '2099-01-01T00:00:00.000Z', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+INSERT INTO portfolios (id, user_id, name, is_primary, status) VALUES
+('pfl_seed_import', 'usr_seed_import', 'Carteira Principal', 1, 'active');
+
+INSERT INTO user_financial_context (
+  id, user_id, financial_goal, monthly_income_range, monthly_investment_target, available_to_invest,
+  risk_profile, risk_profile_self_declared, risk_profile_quiz_result, risk_profile_effective,
+  investment_horizon, platforms_used_json, display_preferences_json, onboarding_step
+) VALUES (
+  'ctx_seed_import',
+  'usr_seed_import',
+  'organizar carteira',
+  '5k-10k',
+  800,
+  400,
+  'moderado',
+  'moderado',
+  'moderado',
+  'moderado',
+  'medio_prazo',
+  '["xp"]',
+  '{"ghostMode":false}',
+  'done'
+);
+
+-- Base de carteira (para deduplicacao)
+INSERT INTO portfolio_positions (
+  id, portfolio_id, asset_id, platform_id, source_kind, status,
+  quantity, average_price, current_price, invested_amount, current_amount, category_label, notes
+) VALUES
+('pos_imp_1', 'pfl_seed_import', 'ast_itsa4', 'plt_xp', 'manual', 'active', 15, 13.50, 14.50, 202.50, 217.50, 'Acoes', 'Posicao previa para testar duplicidade');
+
+-- Import 1: pendente / pronto para revisao
+INSERT INTO imports (
+  id, user_id, portfolio_id, origin, status, file_name, mime_type,
+  total_rows, valid_rows, invalid_rows, duplicate_rows,
+  created_at, started_at, updated_at
+) VALUES (
+  'imp_seed_pending',
+  'usr_seed_import',
+  'pfl_seed_import',
+  'manual',
+  'PREVIEW_READY',
+  'import_manual_demo.json',
+  'application/json',
+  5, 1, 3, 1,
+  CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+);
+
+INSERT INTO import_rows (id, import_id, row_number, source_payload_json, normalized_payload_json, resolution_status, error_message) VALUES
+(
+  'row_imp_1',
+  'imp_seed_pending',
+  1,
+  '{"sourceKind":"manual","name":"Itausa","code":"ITSA4","quantity":5,"investedAmount":67.50,"currentAmount":72.50}',
+  '{"sourceKind":"manual","code":"ITSA4","name":"Itausa","normalizedName":"itausa","quantity":5,"investedAmount":67.50,"currentAmount":72.50,"averagePrice":13.50,"currentPrice":14.50,"categoryLabel":"Acoes","notes":"","fieldSources":{},"fieldConfidences":{},"warnings":[],"reviewMeta":{},"documentMeta":null,"duplicateCandidates":[],"importable":true}',
+  'NORMALIZED',
+  NULL
+),
+(
+  'row_imp_2',
+  'imp_seed_pending',
+  2,
+  '{"sourceKind":"manual","name":"Itausa","code":"ITSA4","quantity":10,"investedAmount":135.00,"currentAmount":145.00}',
+  '{"sourceKind":"manual","code":"ITSA4","name":"Itausa","normalizedName":"itausa","quantity":10,"investedAmount":135.00,"currentAmount":145.00,"averagePrice":13.50,"currentPrice":14.50,"categoryLabel":"Acoes","notes":"","fieldSources":{},"fieldConfidences":{},"warnings":["Possivel duplicidade com posicao existente"],"reviewMeta":{},"documentMeta":null,"duplicateCandidates":[{"assetId":"ast_itsa4","assetCode":"ITSA4","assetName":"Itausa","quantity":15,"investedAmount":202.50,"currentAmount":217.50}],"importable":true}',
+  'PENDING',
+  'Possivel duplicidade com ativo ja existente na carteira.'
+),
+(
+  'row_imp_3',
+  'imp_seed_pending',
+  3,
+  '{"sourceKind":"manual","name":"","code":"","quantity":0}',
+  '{"sourceKind":"manual","code":"","name":"","normalizedName":"","quantity":0,"investedAmount":0,"currentAmount":0,"averagePrice":null,"currentPrice":null,"categoryLabel":"Acoes","notes":"","fieldSources":{},"fieldConfidences":{},"warnings":["Linha invalida"],"reviewMeta":{},"documentMeta":null,"duplicateCandidates":[],"importable":true}',
+  'FAILED',
+  'Linha invalida: faltam campos obrigatorios.'
+),
+(
+  'row_imp_4',
+  'imp_seed_pending',
+  4,
+  '{"sourceKind":"manual","name":"Previdencia Demo","code":"","quantity":1,"investedAmount":10000,"currentAmount":10100}',
+  '{"sourceKind":"manual","code":"","name":"Previdencia Demo","normalizedName":"previdencia demo","quantity":1,"investedAmount":10000,"currentAmount":10100,"averagePrice":10000,"currentPrice":10100,"categoryLabel":"Previdencia","notes":"","fieldSources":{"name":"ia"},"fieldConfidences":{"name":0.45},"warnings":["Baixa confianca em campo critico"],"reviewMeta":{},"documentMeta":{"parserMode":"seed","confidence":0.45},"duplicateCandidates":[],"importable":true}',
+  'PENDING_CRITICAL',
+  'Ha campos criticos com baixa confianca.'
+),
+(
+  'row_imp_5',
+  'imp_seed_pending',
+  5,
+  '{"sourceKind":"manual","name":"Documento nao importavel","code":"","quantity":1}',
+  '{"sourceKind":"manual","code":"","name":"Documento nao importavel","normalizedName":"documento nao importavel","quantity":1,"investedAmount":0,"currentAmount":0,"averagePrice":null,"currentPrice":null,"categoryLabel":"Outros","notes":"","fieldSources":{},"fieldConfidences":{},"warnings":["Documento identificado como nao importavel"],"reviewMeta":{},"documentMeta":{"importable":false},"duplicateCandidates":[],"importable":false}',
+  'BLOCKED_NON_IMPORTABLE',
+  'Documento identificado como nao importavel para posicao de carteira.'
+);
+
+-- Import 2: concluida com snapshot (para testar Imports Center com snapshot_id)
+INSERT INTO imports (
+  id, user_id, portfolio_id, origin, status, file_name, mime_type,
+  total_rows, valid_rows, invalid_rows, duplicate_rows,
+  created_at, started_at, updated_at, finished_at
+) VALUES (
+  'imp_seed_done',
+  'usr_seed_import',
+  'pfl_seed_import',
+  'manual',
+  'COMMITTED',
+  'import_done_demo.json',
+  'application/json',
+  1, 1, 0, 0,
+  CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+);
+
+INSERT INTO portfolio_snapshots (
+  id, portfolio_id, import_id, reference_date, total_equity, total_invested, total_profit_loss, total_profit_loss_pct
+) VALUES
+('snp_imp_1', 'pfl_seed_import', 'imp_seed_done', '2026-03-31', 217.50, 202.50, 15.00, 7.41);
+
+INSERT INTO portfolio_snapshot_positions (id, snapshot_id, asset_id, quantity, unit_price, current_value) VALUES
+('snp_imp_1_itsa4', 'snp_imp_1', 'ast_itsa4', 15, 14.50, 217.50);
+
+INSERT INTO operational_events (id, user_id, portfolio_id, event_type, event_status, message) VALUES
+('evt_imp_1', 'usr_seed_import', 'pfl_seed_import', 'seed_created', 'ok', 'Cenario import criado (pendente e concluido).');

--- a/database/seeds/seed_onboarding_no_context.sql
+++ b/database/seeds/seed_onboarding_no_context.sql
@@ -1,0 +1,14 @@
+-- Cenario extra: onboarding (sem contexto preenchido)
+-- Objetivo: forcar `hasContext = 0` nas rotas que dependem de `user_financial_context`.
+
+INSERT INTO users (id, cpf, email, password_hash, display_name, status) VALUES
+('usr_seed_onboarding', '10101010101', 'onboarding@example.com', 'pbkdf2_sha256$210000$AQIDBAUGBwgJCgsMDQ4PEA$jbWPdVpAx7pu8ZCx0wY0j1VsKVnFfedYNCZR6r-R19Y', 'Usuario Onboarding', 'ACTIVE');
+
+INSERT INTO auth_sessions (id, user_id, session_token_hash, remember_device, expires_at, created_at, last_seen_at) VALUES
+('ses_seed_onboarding', 'usr_seed_onboarding', '82bdc0432ffefc6e289e08dbd56fb730bdd8c69a38f8d437d43e01dce3f2db97', 1, '2099-01-01T00:00:00.000Z', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+INSERT INTO portfolios (id, user_id, name, is_primary, status) VALUES
+('pfl_seed_onboarding', 'usr_seed_onboarding', 'Carteira Principal', 1, 'active');
+
+INSERT INTO operational_events (id, user_id, portfolio_id, event_type, event_status, message) VALUES
+('evt_onb_1', 'usr_seed_onboarding', 'pfl_seed_onboarding', 'seed_created', 'ok', 'Cenario onboarding criado (sem contexto).');


### PR DESCRIPTION
Objetivo\n- Permitir validar o MVP com dados minimamente realistas sem depender de producao.\n\nO que entra\n- seed_base.sql alinhada ao schema oficial + cenarios base.\n- Seeds adicionais: onboarding sem contexto e cenario de import (pendente e committed com snapshot).\n- README com ordem de aplicacao, credenciais e tokens de cookie conhecidos (squilo_session).\n\nEvidencia\n- Executei database/d1/schema.sql + todos seeds via SQLite local (Python sqlite3.executescript) sem erro.