### PR TITLE
Historico: timeline real (snapshots + eventos)

### DIFF
--- a/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/src/repositories/history_repository.ts
+++ b/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/src/repositories/history_repository.ts
@@ -47,6 +47,34 @@ export async function findHistorySessionStateByTokenHash(env: Env, tokenHash: st
 }
 
 export async function findPortfolioSnapshots(env: Env, portfolioId: string): Promise<SnapshotHistoryRow[]> {
+  return await findPortfolioSnapshotsLimited(env, { portfolioId });
+}
+
+export async function findPortfolioSnapshotsLimited(env: Env, input: {
+  portfolioId: string;
+  limit?: number | null;
+}): Promise<SnapshotHistoryRow[]> {
+  const limit = input.limit == null ? null : Math.max(1, Math.min(200, input.limit));
+
+  if (limit) {
+    return await d1(env).all<SnapshotHistoryRow>(
+      `SELECT
+         id,
+         portfolio_id,
+         reference_date,
+         total_equity,
+         total_invested,
+         total_profit_loss,
+         total_profit_loss_pct,
+         created_at
+       FROM portfolio_snapshots
+       WHERE portfolio_id = ?
+       ORDER BY reference_date DESC, created_at DESC
+       LIMIT ?`,
+      [input.portfolioId, limit]
+    );
+  }
+
   return await d1(env).all<SnapshotHistoryRow>(
     `SELECT
        id,
@@ -60,7 +88,7 @@ export async function findPortfolioSnapshots(env: Env, portfolioId: string): Pro
      FROM portfolio_snapshots
      WHERE portfolio_id = ?
      ORDER BY reference_date DESC, created_at DESC`,
-    [portfolioId]
+    [input.portfolioId]
   );
 }
 

--- a/database/seeds/seed_base.sql
+++ b/database/seeds/seed_base.sql
@@ -69,6 +69,7 @@ INSERT INTO portfolio_positions (
 INSERT INTO portfolio_snapshots (
   id, portfolio_id, import_id, reference_date, total_equity, total_invested, total_profit_loss, total_profit_loss_pct
 ) VALUES
+('snp_bal_0', 'pfl_seed_balanced', NULL, '2026-02-28', 20350.00, 20100.00, 250.00, 1.24),
 ('snp_bal_1', 'pfl_seed_balanced', NULL, '2026-03-31', 21276.84, 20742.58, 534.26, 2.58);
 
 INSERT INTO portfolio_snapshot_positions (id, snapshot_id, asset_id, quantity, unit_price, current_value) VALUES
@@ -101,6 +102,9 @@ INSERT INTO analysis_insights (id, analysis_id, insight_type, title, message, pr
 
 INSERT INTO operational_events (id, user_id, portfolio_id, event_type, event_status, message) VALUES
 ('evt_bal_1', 'usr_seed_balanced', 'pfl_seed_balanced', 'seed_created', 'ok', 'Cenario balanced criado.');
+
+INSERT INTO operational_events (id, user_id, portfolio_id, event_type, event_status, message, occurred_at) VALUES
+('evt_bal_2', 'usr_seed_balanced', 'pfl_seed_balanced', 'snapshot_created', 'ok', 'Snapshot inicial gerado.', '2026-03-01T00:00:00.000Z');
 
 -- Cenario 2: carteira concentrada (edge case de concentracao)
 INSERT INTO users (id, cpf, email, password_hash, display_name, status) VALUES

--- a/services/api/openapi.yaml
+++ b/services/api/openapi.yaml
@@ -404,6 +404,11 @@ paths:
   /v1/history/snapshots:
     get:
       summary: Ler snapshots do historico
+      parameters:
+        - in: query
+          name: limit
+          required: false
+          schema: { type: integer, minimum: 1, maximum: 200, default: 20 }
       responses:
         '200':
           description: OK
@@ -411,6 +416,40 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiOkHistorySnapshots'
+        '401':
+          description: Nao autenticado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelopeError'
+        '404':
+          description: Nao encontrado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelopeError'
+        '500':
+          description: Erro interno
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelopeError'
+
+  /v1/history/timeline:
+    get:
+      summary: Ler timeline (snapshots + eventos)
+      parameters:
+        - in: query
+          name: limit
+          required: false
+          schema: { type: integer, minimum: 10, maximum: 200, default: 80 }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiOkHistoryTimeline'
         '401':
           description: Nao autenticado
           content:
@@ -941,6 +980,10 @@ components:
       type: object
       additionalProperties: true
 
+    HistoryTimelineData:
+      type: object
+      additionalProperties: true
+
     HistoryImportsCenterData:
       type: object
       additionalProperties: true
@@ -1052,6 +1095,14 @@ components:
           properties:
             data:
               $ref: '#/components/schemas/HistorySnapshotsData'
+
+    ApiOkHistoryTimeline:
+      allOf:
+        - $ref: '#/components/schemas/ApiEnvelopeOk'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/HistoryTimelineData'
 
     ApiOkHistoryImportsCenter:
       allOf:


### PR DESCRIPTION
Resolve #187 e endereca #236 (E2E-017).\n\nO que mudou\n- GET /v1/history/timeline: agrega snapshots + eventos operacionais em ordem temporal com recomendacao por snapshot quando houver analise.\n- /v1/history/snapshots agora respeita query param limit.\n- Seeds: cenario balanced agora tem 2 snapshots + 2 eventos (nao fica vazio sem motivo).\n- Contratos e OpenAPI atualizados (services/api + packages/contracts).\n\nNotas\n- PR empilhado: base = codex/issue-220-first-access-openapi (PR #277).