### PR TITLE
Web: primeiro acesso (entry flow) orientado pela Home

### DIFF
--- a/apps/web/src/app/README.md
+++ b/apps/web/src/app/README.md
@@ -5,10 +5,10 @@ Esta pasta define a cola minima do `apps/web` sem assumir framework.
 ## O que existe aqui
 - `AppShell` "headless" (router + estado global + wiring de data sources)
 - rotas base coerentes com `docs/20_product/telas_e_servicos.md`
+- regra de entrada (primeiro acesso) baseada em `screenState` da Home
 
 ## Regra desta fase
 Enquanto o `apps/web` nao for um projeto Node real, este codigo existe para:
 - evitar convencoes paralelas
 - deixar claro o contrato de navegacao e estado
 - permitir plugar telas por modulo sem espalhar fetch/JSON
-

--- a/apps/web/src/app/entry_flow.ts
+++ b/apps/web/src/app/entry_flow.ts
@@ -1,0 +1,53 @@
+import type { AppDataSources } from '../core/data';
+import { createRouter, type Router, type RouterLocationLike } from '../core/router';
+
+export type EntryFlowReason =
+  | 'redirect_onboarding'
+  | 'ready'
+  | 'empty'
+  | 'analysis_pending'
+  | 'backend_error';
+
+export interface EntryFlowResult {
+  reason: EntryFlowReason;
+  nextPathname: string;
+}
+
+export interface ResolveEntryFlowInput {
+  dataSources: AppDataSources;
+  router?: Router;
+  currentLocation?: RouterLocationLike;
+}
+
+/**
+ * Resolve o primeiro destino do app.
+ * Regra MVP: nao quebrar no primeiro acesso; orientar pro proximo passo.
+ *
+ * Fonte dominante: `GET /v1/dashboard/home` (screenState).
+ */
+export async function resolveEntryFlow(input: ResolveEntryFlowInput): Promise<EntryFlowResult> {
+  const router = input.router ?? createRouter();
+  const current = input.currentLocation ?? { pathname: '/' };
+
+  const home = await input.dataSources.dashboard.getDashboardHome();
+  if (!home.ok) {
+    // Se o backend falhar no primeiro acesso, nao joga erro tecnico pra UI; volta pro splash.
+    return { reason: 'backend_error', nextPathname: router.build(router.parse(current)) };
+  }
+
+  const data = home.data;
+  if (data.screenState === 'redirect_onboarding') {
+    return { reason: 'redirect_onboarding', nextPathname: data.redirectTo || '/onboarding' };
+  }
+
+  if (data.screenState === 'empty') {
+    return { reason: 'empty', nextPathname: '/home' };
+  }
+
+  if (data.screenState === 'portfolio_ready_analysis_pending') {
+    return { reason: 'analysis_pending', nextPathname: '/home' };
+  }
+
+  return { reason: 'ready', nextPathname: '/home' };
+}
+


### PR DESCRIPTION
Atende #220 (E2E-001) no apps/web (sem layout) e cobre a intencao da #13 (US002: entrar sem friccao) ao direcionar o usuario para valor/acao com o minimo de passos.\n\nO que entra:\n- resolveEntryFlow baseado em GET /v1/dashboard/home (screenState=redirect_onboarding/empty/pending/ready)\n- AppShell.resolveFirstAccess() atualiza a rota de forma deterministica\n\nPendencias para fechar US002 com evidencia completa:\n- contrato oficial em services/api (hoje openapi so cobre imports) para /v1/dashboard/home e sessao\n- amarrar o backend de sessao/auth ao schema oficial sem gambiarras