### PR TITLE
Web: onboarding (contexto) headless + mocks hml sem contexto

### DIFF
--- a/apps/web/src/core/data/mock/hml/dashboard_home.json
+++ b/apps/web/src/core/data/mock/hml/dashboard_home.json
@@ -1,75 +1,12 @@
 {
   "ok": true,
   "meta": {
-    "requestId": "req_local_home",
+    "requestId": "req_hml_home",
     "timestamp": "2026-03-31T01:00:00Z",
     "version": "v1"
   },
   "data": {
-    "screenState": "ready",
-    "portfolioId": "pfl_seed_balanced",
-    "hero": {
-      "totalEquity": 21276.84,
-      "totalInvested": 20742.58,
-      "totalProfitLoss": 534.26,
-      "totalProfitLossPct": 2.58,
-      "statusLabel": "Analise concluida"
-    },
-    "score": { "value": 72, "status": "atencao_moderada", "explanation": "Boa base, mas com concentracao excessiva em previdencia." },
-    "primaryProblem": {
-      "code": "concentracao",
-      "title": "Concentracao em Previdencia",
-      "body": "Sua carteira ainda esta concentrada demais em previdencia.",
-      "severity": "warning"
-    },
-    "primaryAction": {
-      "code": "diluir_concentracao",
-      "title": "Diluir concentracao aos poucos",
-      "body": "Use novos aportes para abrir mais equilibrio fora da previdencia.",
-      "ctaLabel": "Ver carteira",
-      "target": "/portfolio"
-    },
-    "distribution": [
-      {
-        "key": "PENSION",
-        "label": "Previdencia",
-        "value": 15350.0,
-        "sharePct": 72.15,
-        "performancePct": 0,
-        "sourceType": "PENSION"
-      },
-      {
-        "key": "FUND",
-        "label": "Fundos",
-        "value": 5200.0,
-        "sharePct": 24.44,
-        "performancePct": 0,
-        "sourceType": "FUND"
-      },
-      {
-        "key": "STOCK",
-        "label": "Acoes",
-        "value": 726.84,
-        "sharePct": 3.41,
-        "performancePct": 0,
-        "sourceType": "STOCK"
-      }
-    ],
-    "insights": [
-      {
-        "kind": "concentration",
-        "title": "Previdência pesa demais",
-        "body": "Sua proteção virou bloco grande demais dentro da carteira.",
-        "severity": "warning"
-      },
-      {
-        "kind": "balance",
-        "title": "Ações ainda têm pouco peso",
-        "body": "Há espaço para crescimento ganhar mais relevância ao longo do tempo.",
-        "severity": "info"
-      }
-    ],
-    "updatedAt": "2026-03-31T01:00:00Z",
-    "sourceWarning": null
+    "screenState": "redirect_onboarding",
+    "redirectTo": "/onboarding"
   }
 }

--- a/apps/web/src/core/data/mock/hml/profile_context.json
+++ b/apps/web/src/core/data/mock/hml/profile_context.json
@@ -1,32 +1,32 @@
 {
   "ok": true,
   "meta": {
-    "requestId": "req_local_profile",
+    "requestId": "req_hml_profile",
     "timestamp": "2026-03-31T01:00:00Z",
     "version": "v1"
   },
   "data": {
-    "userId": "usr_seed_balanced",
-    "portfolioId": "pfl_seed_balanced",
+    "userId": "usr_hml_no_context",
+    "portfolioId": null,
     "context": {
-      "financialGoal": "equilibrar e crescer",
-      "monthlyIncomeRange": "10k-15k",
-      "monthlyInvestmentTarget": 1000,
-      "availableToInvest": 500,
-      "riskProfileSelfDeclared": "moderado",
-      "riskProfileQuizResult": "moderado",
-      "riskProfileEffective": "moderado",
-      "investmentHorizon": "longo_prazo",
-      "platformsUsed": { "platformIds": ["xp", "ion"], "otherPlatforms": [] },
+      "financialGoal": null,
+      "monthlyIncomeRange": null,
+      "monthlyInvestmentTarget": null,
+      "availableToInvest": null,
+      "riskProfileSelfDeclared": null,
+      "riskProfileQuizResult": null,
+      "riskProfileEffective": null,
+      "investmentHorizon": null,
+      "platformsUsed": null,
       "displayPreferences": { "ghostMode": false }
     },
     "onboarding": {
-      "currentStep": "confirm",
-      "completed": true,
-      "completedAt": "2026-03-31T00:00:00.000Z",
-      "homeUnlocked": true,
-      "completedSteps": ["goal", "risk_quiz", "income_horizon", "platforms", "confirm"],
-      "missing": []
+      "currentStep": "goal",
+      "completed": false,
+      "completedAt": null,
+      "homeUnlocked": false,
+      "completedSteps": [],
+      "missing": ["financialGoal", "monthlyIncomeRange", "investmentHorizon", "riskProfileEffective", "platformsUsed.platformIds"]
     },
     "backendHealth": {
       "status": "ok",

--- a/apps/web/src/features/onboarding/README.md
+++ b/apps/web/src/features/onboarding/README.md
@@ -11,9 +11,8 @@ O onboarding usa `GET/PUT /v1/profile/context` como fonte de verdade:
 
 ## Estados obrigatorios (E2E-002 / E2E-018)
 - sem contexto: guiar passo a passo usando `onboarding.missing`
-- revisao: permitir confirmar antes de concluir (`step=confirm`)
+- revisao: permitir confirmar antes de concluir (`review` local + `step=confirm`)
 - concluido: redirecionar para Home (ou proxima etapa definida)
 
 ## Regra
 Nao fazer roundtrip por clique: persistir por etapa concluida (goal, risk_quiz, income_horizon, platforms, confirm).
-

--- a/apps/web/src/features/onboarding/onboarding_controller.ts
+++ b/apps/web/src/features/onboarding/onboarding_controller.ts
@@ -1,0 +1,80 @@
+import type { ProfileContextPayload, ProfileContextStep, ProfileOnboardingState, ProfileContextPutData } from '../../core/data/contracts';
+import type { ProfileDataSource } from '../../core/data/data_sources';
+
+export type OnboardingDraft = Partial<ProfileContextPayload>;
+
+export interface OnboardingReview {
+  readyToConfirm: boolean;
+  missing: string[];
+  summary: Record<string, unknown>;
+}
+
+export interface OnboardingController {
+  load(): ReturnType<ProfileDataSource['getProfileContext']>;
+  submitStep(step: Exclude<ProfileContextStep, 'confirm'>, patch: OnboardingDraft): ReturnType<ProfileDataSource['putProfileContext']>;
+  review(draft: OnboardingDraft, onboarding: ProfileOnboardingState): OnboardingReview;
+  confirm(draft: OnboardingDraft): Promise<{ ok: boolean; data?: ProfileContextPutData; nextPathname: string }>;
+}
+
+/**
+ * Controller headless do onboarding.
+ * Sem UI: a tela apenas chama `submitStep`, usa `review` local, e finaliza com `confirm`.
+ */
+export function createOnboardingController(input: { profile: ProfileDataSource }): OnboardingController {
+  const profile = input.profile;
+
+  return {
+    load() {
+      return profile.getProfileContext();
+    },
+    submitStep(step, patch) {
+      return profile.putProfileContext({
+        step,
+        context: patch
+      });
+    },
+    review(draft, onboarding) {
+      const missing = onboarding.missing ?? [];
+      const readyToConfirm = missing.length === 0 && isDraftCompleteEnough(draft);
+
+      return {
+        readyToConfirm,
+        missing,
+        summary: {
+          financialGoal: draft.financialGoal ?? null,
+          monthlyIncomeRange: draft.monthlyIncomeRange ?? null,
+          investmentHorizon: draft.investmentHorizon ?? null,
+          riskProfileSelfDeclared: draft.riskProfileSelfDeclared ?? null,
+          platformsUsed: draft.platformsUsed ?? null
+        }
+      };
+    },
+    async confirm(draft) {
+      const result = await profile.putProfileContext({
+        step: 'confirm',
+        context: draft
+      });
+
+      if (!result.ok) {
+        return { ok: false, nextPathname: '/onboarding' };
+      }
+
+      const nextPathname = result.data.onboarding.homeUnlocked ? '/home' : '/onboarding';
+      return { ok: true, data: result.data, nextPathname };
+    }
+  };
+}
+
+function isDraftCompleteEnough(draft: OnboardingDraft): boolean {
+  // Critico para destravar leitura: goal + risk + horizon + platforms + income.
+  return Boolean(
+    draft.financialGoal &&
+    draft.monthlyIncomeRange &&
+    draft.investmentHorizon &&
+    (draft.riskProfileEffective || draft.riskProfileQuizResult || draft.riskProfileSelfDeclared) &&
+    draft.platformsUsed &&
+    Array.isArray(draft.platformsUsed.platformIds) &&
+    draft.platformsUsed.platformIds.length > 0
+  );
+}
+


### PR DESCRIPTION
Atende #221 (E2E-002) no pps/web (sem layout).\n\n- eatures/onboarding: createOnboardingController (submitStep + review local + confirm) baseado em GET/PUT /v1/profile/context\n- core/data mock provider: aplica patch no retorno e evolui onboarding por step\n- mock_hml: simula primeiro acesso sem contexto (dashboard redirect_onboarding + profile_context incompleto)\n\nObjetivo: deixar a jornada pluggable e previsivel quando o web virar Node real.