### PR TITLE
Web: perfil (edicao de contexto) headless

### DIFF
--- a/apps/web/src/features/profile/README.md
+++ b/apps/web/src/features/profile/README.md
@@ -19,4 +19,4 @@ O perfil melhora a leitura da carteira. Não deve parecer cadastro bancário cha
 
 ## Estados (E2E-003)
 - ao reabrir, dados devem reaparecer iguais ao salvo (fonte de verdade = GET /v1/profile/context).
-- salvar deve atualizar `onboarding` quando o usuário concluir o fluxo.
+- salvar após onboarding usa PUT sem `step` (patch em `context`), para nao reabrir onboarding.

--- a/apps/web/src/features/profile/profile_controller.ts
+++ b/apps/web/src/features/profile/profile_controller.ts
@@ -1,0 +1,38 @@
+import type { ProfileContextPayload, ProfileContextPutData } from '../../core/data/contracts';
+import type { ProfileDataSource } from '../../core/data/data_sources';
+
+export type ProfilePatch = Partial<ProfileContextPayload>;
+
+export interface ProfileController {
+  load(): ReturnType<ProfileDataSource['getProfileContext']>;
+  save(patch: ProfilePatch): Promise<{ ok: boolean; data?: ProfileContextPutData }>;
+}
+
+/**
+ * Edicao posterior do perfil (E2E-003).
+ * Regra: enviar patch dentro de `context` e sem `step` para nao reabrir onboarding.
+ */
+export function createProfileController(input: { profile: ProfileDataSource }): ProfileController {
+  const profile = input.profile;
+
+  return {
+    load() {
+      return profile.getProfileContext();
+    },
+    async save(patch) {
+      const result = await profile.putProfileContext({ context: sanitizePatch(patch) });
+      if (!result.ok) return { ok: false };
+      return { ok: true, data: result.data };
+    }
+  };
+}
+
+function sanitizePatch(patch: ProfilePatch): ProfilePatch {
+  // Evita escrever "undefined" no wire. `null` continua permitido (se a UI quiser limpar).
+  const clean: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(patch)) {
+    if (v !== undefined) clean[k] = v;
+  }
+  return clean as ProfilePatch;
+}
+


### PR DESCRIPTION
Atende #212 (parte Perfil) e #222 (E2E-003) no pps/web (sem layout).\n\n- eatures/profile: createProfileController (load + save patch) sobre GET/PUT /v1/profile/context\n- PUT envia patch em context e sem step para evitar reabrir onboarding/duplicar dados\n\nStack: baseia na branch do onboarding (#221).