### PR TITLE
Web: Home controller (navegacao contextual)

### DIFF
--- a/apps/web/src/features/home/README.md
+++ b/apps/web/src/features/home/README.md
@@ -19,3 +19,7 @@ Responder rápido como a carteira está, qual é o principal ponto de atenção 
 ## Regra
 A Home deve caber em leitura rápida.
 Uma ação principal por vez.
+
+## Navegacao (E2E-010)
+- CTA principal vem de `primaryAction.target`
+- targets devem ser validados contra o router para evitar rota orfa

--- a/apps/web/src/features/home/home_controller.ts
+++ b/apps/web/src/features/home/home_controller.ts
@@ -1,0 +1,83 @@
+import type { ApiDashboardHomeEnvelope, DashboardHomeData, ScreenStateRedirect } from '../../core/data/contracts';
+import type { DashboardDataSource } from '../../core/data/data_sources';
+import { tryParseRoute, type AppRoute } from '../../core/router';
+
+export interface HomeNavigationTargets {
+  primaryAction?: { label: string; pathname: string; route: AppRoute };
+  openPortfolio?: { pathname: string; route: AppRoute };
+  openRadar?: { pathname: string; route: AppRoute };
+  openHoldingDetail?: { pathname: string; route: AppRoute };
+}
+
+export interface HomeControllerResult {
+  envelope: ApiDashboardHomeEnvelope;
+  nav: HomeNavigationTargets;
+}
+
+export interface HomeController {
+  load(): Promise<HomeControllerResult>;
+}
+
+/**
+ * Controller headless da Home:
+ * - centraliza leitura do contrato
+ * - prepara targets de navegacao (E2E-010) de forma valida contra o router
+ */
+export function createHomeController(input: { dashboard: DashboardDataSource }): HomeController {
+  const dashboard = input.dashboard;
+
+  return {
+    async load() {
+      const envelope = await dashboard.getDashboardHome();
+      if (!envelope.ok) return { envelope, nav: {} };
+
+      const nav = resolveNav(envelope.data);
+      return { envelope, nav };
+    }
+  };
+}
+
+function resolveNav(data: DashboardHomeData): HomeNavigationTargets {
+  if (data.screenState === 'redirect_onboarding') {
+    const redirect = data as ScreenStateRedirect;
+    const route = tryParseRoute({ pathname: redirect.redirectTo }) ?? { id: 'onboarding' };
+    return {
+      primaryAction: { label: 'Completar onboarding', pathname: redirect.redirectTo, route }
+    };
+  }
+
+  if (data.screenState !== 'ready' && data.screenState !== 'portfolio_ready_analysis_pending' && data.screenState !== 'empty') {
+    return {};
+  }
+
+  const targets: HomeNavigationTargets = {};
+
+  // CTA principal vem do backend; valida antes de expor.
+  if ('primaryAction' in data && data.primaryAction?.target) {
+    const pathname = data.primaryAction.target;
+    const route = tryParseRoute({ pathname });
+    if (route) {
+      targets.primaryAction = { label: data.primaryAction.ctaLabel, pathname, route };
+    }
+  }
+
+  const portfolioRoute = tryParseRoute({ pathname: '/portfolio' });
+  if (portfolioRoute) targets.openPortfolio = { pathname: '/portfolio', route: portfolioRoute };
+
+  const radarRoute = tryParseRoute({ pathname: '/radar' });
+  if (radarRoute) targets.openRadar = { pathname: '/radar', route: radarRoute };
+
+  // Se o backend no futuro sugerir um holdingId alvo, a Home ja sabe montar o destino.
+  // Aqui fica "best effort": usa portfolioId do payload quando existir.
+  if ('portfolioId' in data && typeof data.portfolioId === 'string' && data.portfolioId) {
+    const exampleHoldingId = null as string | null;
+    if (exampleHoldingId) {
+      const pathname = `/portfolio/${encodeURIComponent(data.portfolioId)}/holdings/${encodeURIComponent(exampleHoldingId)}`;
+      const route = tryParseRoute({ pathname });
+      if (route) targets.openHoldingDetail = { pathname, route };
+    }
+  }
+
+  return targets;
+}
+


### PR DESCRIPTION
Atende #229 (E2E-010) e complementa #209 (TEC-040) no pps/web (sem layout).\n\n- core/router: 	ryParseRoute para validar paths\n- eatures/home: createHomeController que consome GET /v1/dashboard/home e expõe targets de navegacao (CTA, Carteira, Radar) validos\n\nStack: baseia na branch atual da cadeia de controllers.