### PR TITLE
Web: detalhe do ativo controller (headless)

### DIFF
--- a/apps/web/src/core/data/providers/mock_provider.ts
+++ b/apps/web/src/core/data/providers/mock_provider.ts
@@ -59,6 +59,18 @@ export function createLocalMockDataSources(options: MockProviderOptions): AppDat
     },
     holdingDetail: {
       async getHoldingDetail(input: { portfolioId: string; holdingId: string }): Promise<ApiHoldingDetailEnvelope> {
+        if (basePath.includes('apps/web/src/core/data/mock/hml')) {
+          return {
+            ok: true,
+            meta: {
+              requestId: 'req_hml_holding_redirect',
+              timestamp: new Date().toISOString(),
+              version: 'v1'
+            },
+            data: { screenState: 'redirect_onboarding', redirectTo: '/onboarding' }
+          };
+        }
+
         // Mock deterministico por holdingId, para cobrir fundo/previdencia/acao sem UI real.
         const holdingId = input.holdingId;
         const file =

--- a/apps/web/src/features/holding_detail/README.md
+++ b/apps/web/src/features/holding_detail/README.md
@@ -17,3 +17,6 @@ Detalhe existe para orientar decisao. Se nao muda acao, nao merece complexidade.
 
 ## Tipos (US034/US035)
 A tela pode variar blocos com base em `holding.assetTypeCode` (ex.: `FUND` vs `PENSION`) sem mudar o contrato base.
+
+## Implementacao (sem layout)
+`holding_detail_controller.ts` centraliza leitura do contrato e targets de navegacao.

--- a/apps/web/src/features/holding_detail/holding_detail_controller.ts
+++ b/apps/web/src/features/holding_detail/holding_detail_controller.ts
@@ -1,0 +1,68 @@
+import type { ApiHoldingDetailEnvelope, HoldingDetailData, HoldingDetailDataReady } from '../../core/data/contracts';
+import type { HoldingDetailDataSource } from '../../core/data/data_sources';
+import { createRouter, type Router } from '../../core/router';
+
+export type HoldingDetailViewModel =
+  | { kind: 'redirect_onboarding'; redirectTo: string }
+  | {
+      kind: 'ready';
+      holding: HoldingDetailDataReady['holding'];
+      ranking: HoldingDetailDataReady['ranking'];
+      recommendation: HoldingDetailDataReady['recommendation'];
+      categoryContext: HoldingDetailDataReady['categoryContext'];
+      externalLink: string | null;
+      targets: {
+        backToPortfolio: { pathname: string };
+      };
+    }
+  | { kind: 'error'; code?: string; message?: string };
+
+export interface HoldingDetailControllerResult {
+  envelope: ApiHoldingDetailEnvelope;
+  viewModel: HoldingDetailViewModel;
+}
+
+export interface HoldingDetailController {
+  load(input: { portfolioId: string; holdingId: string }): Promise<HoldingDetailControllerResult>;
+}
+
+/**
+ * Controller headless do detalhe:
+ * - centraliza leitura do contrato do backend novo
+ * - suporta redirect_onboarding
+ * - expõe target de navegacao de volta para Carteira
+ */
+export function createHoldingDetailController(input: { holdingDetail: HoldingDetailDataSource; router?: Router }): HoldingDetailController {
+  const ds = input.holdingDetail;
+  const router = input.router ?? createRouter();
+
+  return {
+    async load(params) {
+      const envelope = await ds.getHoldingDetail(params);
+      if (!envelope.ok) {
+        return { envelope, viewModel: { kind: 'error', code: envelope.error.code, message: envelope.error.message } };
+      }
+
+      const data = envelope.data as HoldingDetailData;
+      if ('screenState' in data && data.screenState === 'redirect_onboarding') {
+        return { envelope, viewModel: { kind: 'redirect_onboarding', redirectTo: data.redirectTo || '/onboarding' } };
+      }
+
+      const ready = data as HoldingDetailDataReady;
+      return {
+        envelope,
+        viewModel: {
+          kind: 'ready',
+          holding: ready.holding,
+          ranking: ready.ranking,
+          recommendation: ready.recommendation,
+          categoryContext: ready.categoryContext,
+          externalLink: ready.externalLink ?? null,
+          targets: {
+            backToPortfolio: { pathname: router.build({ id: 'portfolio' }) }
+          }
+        }
+      };
+    }
+  };
+}


### PR DESCRIPTION
Atende #211 (TEC-042) e #44 (US033) no pps/web (sem layout).\n\n- eatures/holding_detail: createHoldingDetailController para consumir GET /v1/portfolio/{portfolioId}/holdings/{holdingId}, suportar redirect_onboarding e expor target de volta para /portfolio\n- core/data mock provider: no modo hml, holding detail redireciona para onboarding (coerente com primeiro acesso)\n\nObjetivo: detalhe pluggable e consistente com a jornada sem inventar UI.