### PR TITLE
Web: imports flow (data source + controller headless)

### DIFF
--- a/apps/web/src/core/data/contracts.ts
+++ b/apps/web/src/core/data/contracts.ts
@@ -12,6 +12,60 @@ export type EmptyState = {
   target: string;
 };
 
+// ===== Imports =====
+
+export type ImportTotals = {
+  totalRows: number;
+  validRows: number;
+  invalidRows: number;
+  duplicateRows: number;
+};
+
+export type ImportStartData = {
+  importId: string;
+  status: string;
+  nextStep: string;
+  importable: boolean;
+  totals?: ImportTotals;
+  document?: unknown | null;
+};
+
+export type ImportPreviewRow = {
+  id: string;
+  rowNumber: number;
+  source: Record<string, unknown>;
+  normalized: Record<string, unknown>;
+  resolutionStatus: string;
+  errorMessage: string | null;
+  fieldSources: Record<string, unknown>;
+  fieldConfidences: Record<string, unknown>;
+  warnings: unknown[];
+  reviewMeta: Record<string, unknown>;
+};
+
+export type ImportPreviewData = {
+  importId: string;
+  status: string;
+  origin: string;
+  readyToCommit: boolean;
+  importable: boolean;
+  totals?: ImportTotals;
+  document?: unknown | null;
+  rows: ImportPreviewRow[];
+};
+
+export type ImportCommitData = {
+  importId: string;
+  status: string;
+  createdSnapshotId: string;
+  affectedPositions: number;
+  nextStep: string;
+};
+
+export type ApiImportStartEnvelope = ApiEnvelope<ImportStartData>;
+export type ApiImportPreviewEnvelope = ApiEnvelope<ImportPreviewData>;
+export type ApiImportCommitEnvelope = ApiEnvelope<ImportCommitData>;
+
 // ===== Analysis (Radar) =====
 
 export type AnalysisPendingData = {

--- a/apps/web/src/features/imports/README.md
+++ b/apps/web/src/features/imports/README.md
@@ -1,0 +1,18 @@
+# Feature Imports
+
+## Objetivo
+Permitir entrada/atualizacao de dados com preview antes do commit.
+
+## Contrato
+- `POST /v1/imports/start`
+- `GET /v1/imports/{importId}/preview`
+- `POST /v1/imports/{importId}/commit`
+
+## Regra
+- nunca commitar sem preview
+- nao maquiar invalido/duplicado/conflito
+- o fluxo deve gerar proximo passo claro (`nextStep`)
+
+## Implementacao (sem layout)
+`imports_controller.ts` encapsula start/preview/commit e devolve o minimo para a UI navegar.
+


### PR DESCRIPTION
Atende #213 (TEC-044) e #22 (US011) no pps/web (sem layout).\n\n- core/data: contratos TS de Imports + AppDataSources.imports\n- providers HTTP/mock: start/preview/commit (payload opcional no start)\n- mocks locais: imports_start.json, imports_preview.json, imports_commit.json\n- eatures/imports: controller headless para orquestrar start/preview/commit e navegar via nextStep\n\nRegra: preview antes do commit, sem maquiar invalido/erro.