### PR TITLE
Web: Radar/Historico controllers + report de coerencia

### DIFF
--- a/apps/web/src/features/analysis/README.md
+++ b/apps/web/src/features/analysis/README.md
@@ -15,3 +15,6 @@ Traduzir a analise consolidada em problema principal + acao principal, sem virar
 ## Regra
 Uma acao principal por vez. O resto so existe para sustentar a decisao.
 
+## Implementacao (sem layout)
+`analysis_controller.ts` centraliza consumo do contrato e targets de navegacao.
+

--- a/apps/web/src/features/analysis/analysis_controller.ts
+++ b/apps/web/src/features/analysis/analysis_controller.ts
@@ -1,0 +1,81 @@
+import type { AnalysisData, ApiAnalysisEnvelope, AnalysisPendingData, AnalysisReadyData } from '../../core/data/contracts';
+import type { AnalysisDataSource } from '../../core/data/data_sources';
+import { createRouter, tryParseRoute, type Router } from '../../core/router';
+
+export type AnalysisViewModel =
+  | { kind: 'redirect_onboarding'; redirectTo: string }
+  | { kind: 'pending'; portfolioId: string; pendingState: AnalysisPendingData['pendingState'] }
+  | {
+      kind: 'ready';
+      portfolioId: string;
+      analysisId: string;
+      snapshotId: string;
+      score: { value: number; status: string; explanation: string };
+      primaryProblem: { code: string; title: string; body: string; severity: string };
+      primaryAction: { code: string; title: string; body: string; ctaLabel: string; target: string };
+      insights: Array<{ kind: string; title: string; body: string; priority: number }>;
+      generatedAt: string;
+      targets: {
+        primaryAction?: { pathname: string };
+        openPortfolio: { pathname: string };
+      };
+    }
+  | { kind: 'error'; code?: string; message?: string };
+
+export interface AnalysisControllerResult {
+  envelope: ApiAnalysisEnvelope;
+  viewModel: AnalysisViewModel;
+}
+
+export interface AnalysisController {
+  load(): Promise<AnalysisControllerResult>;
+}
+
+/**
+ * Radar/Analise: precisa explicar e orientar e ser coerente com a Home.
+ * Este controller centraliza o payload e valida targets de navegacao.
+ */
+export function createAnalysisController(input: { analysis: AnalysisDataSource; router?: Router }): AnalysisController {
+  const analysis = input.analysis;
+  const router = input.router ?? createRouter();
+
+  return {
+    async load() {
+      const envelope = await analysis.getAnalysis();
+      if (!envelope.ok) return { envelope, viewModel: { kind: 'error', code: envelope.error.code, message: envelope.error.message } };
+
+      const data = envelope.data as AnalysisData;
+      if ('screenState' in data && data.screenState === 'redirect_onboarding') {
+        return { envelope, viewModel: { kind: 'redirect_onboarding', redirectTo: data.redirectTo || '/onboarding' } };
+      }
+
+      if ('screenState' in data && data.screenState === 'pending') {
+        return { envelope, viewModel: { kind: 'pending', portfolioId: data.portfolioId, pendingState: data.pendingState } };
+      }
+
+      // ready
+      const ready = data as AnalysisReadyData;
+      const openPortfolio = { pathname: router.build({ id: 'portfolio' }) };
+      const primaryTarget = ready.primaryAction?.target ? tryParseRoute({ pathname: ready.primaryAction.target }) : null;
+
+      return {
+        envelope,
+        viewModel: {
+          kind: 'ready',
+          portfolioId: ready.portfolioId,
+          analysisId: ready.analysisId,
+          snapshotId: ready.snapshotId,
+          score: ready.score,
+          primaryProblem: ready.primaryProblem,
+          primaryAction: ready.primaryAction,
+          insights: ready.insights,
+          generatedAt: ready.generatedAt,
+          targets: {
+            openPortfolio,
+            primaryAction: primaryTarget ? { pathname: ready.primaryAction.target } : undefined
+          }
+        }
+      };
+    }
+  };
+}

--- a/apps/web/src/features/consistency/README.md
+++ b/apps/web/src/features/consistency/README.md
@@ -1,0 +1,11 @@
+# Feature Consistency (E2E)
+
+## Objetivo
+Validar consistencia entre Home, Radar e Carteira (E2E-021) para evitar produto contraditorio.
+
+## Regra
+Nao "corrige" nada: apenas sinaliza mismatch.
+
+## Implementacao (sem layout)
+`consistency_controller.ts` roda os controllers headless e devolve um report com issues.
+

--- a/apps/web/src/features/consistency/consistency_controller.ts
+++ b/apps/web/src/features/consistency/consistency_controller.ts
@@ -1,0 +1,74 @@
+import type { AnalysisReadyData, DashboardHomeReadyData, PortfolioDataReady } from '../../core/data/contracts';
+import type { AnalysisDataSource, DashboardDataSource, PortfolioDataSource } from '../../core/data/data_sources';
+import { createAnalysisController } from '../analysis/analysis_controller';
+import { createHomeController } from '../home/home_controller';
+import { createPortfolioController } from '../portfolio/portfolio_controller';
+
+export type ConsistencyIssue =
+  | { kind: 'missing_home_ready' }
+  | { kind: 'missing_analysis_ready' }
+  | { kind: 'score_mismatch'; homeScore: number; analysisScore: number }
+  | { kind: 'primary_problem_mismatch'; homeCode: string; analysisCode: string }
+  | { kind: 'primary_action_mismatch'; homeCode: string; analysisCode: string };
+
+export type ConsistencyReport = {
+  ok: boolean;
+  issues: ConsistencyIssue[];
+  home?: DashboardHomeReadyData;
+  analysis?: AnalysisReadyData;
+  portfolio?: PortfolioDataReady;
+};
+
+/**
+ * Controller headless para E2E-021: garante coerencia entre Home/Radar/Carteira.
+ * Não "corrige" nada; só sinaliza inconsistencias para a UI/testes.
+ */
+export function createConsistencyController(input: {
+  dashboard: DashboardDataSource;
+  analysis: AnalysisDataSource;
+  portfolio: PortfolioDataSource;
+}): { run(): Promise<ConsistencyReport> } {
+  const homeCtrl = createHomeController({ dashboard: input.dashboard });
+  const analysisCtrl = createAnalysisController({ analysis: input.analysis });
+  const portfolioCtrl = createPortfolioController({ portfolio: input.portfolio });
+
+  return {
+    async run() {
+      const [home, analysis, portfolio] = await Promise.all([
+        homeCtrl.load(),
+        analysisCtrl.load(),
+        portfolioCtrl.load()
+      ]);
+
+      const issues: ConsistencyIssue[] = [];
+
+      const homeReady = home.envelope.ok && home.envelope.data.screenState === 'ready' ? (home.envelope.data as DashboardHomeReadyData) : null;
+      const analysisReady = analysis.envelope.ok && analysis.envelope.data.screenState === 'ready' ? (analysis.envelope.data as AnalysisReadyData) : null;
+      const portfolioReady = portfolio.envelope.ok && portfolio.envelope.data.screenState === 'ready' ? (portfolio.envelope.data as PortfolioDataReady) : null;
+
+      if (!homeReady) issues.push({ kind: 'missing_home_ready' });
+      if (!analysisReady) issues.push({ kind: 'missing_analysis_ready' });
+
+      if (homeReady && analysisReady) {
+        if (homeReady.score.value !== analysisReady.score.value) {
+          issues.push({ kind: 'score_mismatch', homeScore: homeReady.score.value, analysisScore: analysisReady.score.value });
+        }
+        if (homeReady.primaryProblem.code !== analysisReady.primaryProblem.code) {
+          issues.push({ kind: 'primary_problem_mismatch', homeCode: homeReady.primaryProblem.code, analysisCode: analysisReady.primaryProblem.code });
+        }
+        if (homeReady.primaryAction.code !== analysisReady.primaryAction.code) {
+          issues.push({ kind: 'primary_action_mismatch', homeCode: homeReady.primaryAction.code, analysisCode: analysisReady.primaryAction.code });
+        }
+      }
+
+      return {
+        ok: issues.length === 0,
+        issues,
+        home: homeReady ?? undefined,
+        analysis: analysisReady ?? undefined,
+        portfolio: portfolioReady ?? undefined
+      };
+    }
+  };
+}
+

--- a/apps/web/src/features/history/README.md
+++ b/apps/web/src/features/history/README.md
@@ -15,3 +15,6 @@ Mostrar trajetoria de forma rastreavel (snapshots + eventos) e orientar proximo 
 ## Regra
 Historico nao e dumping de dado: priorizar o que ajuda o usuario a entender evolucao e proxima acao.
 
+## Implementacao (sem layout)
+`history_controller.ts` consolida snapshots + timeline em uma chamada headless.
+

--- a/apps/web/src/features/history/history_controller.ts
+++ b/apps/web/src/features/history/history_controller.ts
@@ -1,0 +1,95 @@
+import type {
+  ApiHistorySnapshotsEnvelope,
+  ApiHistoryTimelineEnvelope,
+  EmptyState,
+  HistorySnapshotsData,
+  HistorySnapshotsEmptyData,
+  HistorySnapshotsReadyData,
+  HistoryTimelineData,
+  HistoryTimelineEmptyData,
+  HistoryTimelineReadyData
+} from '../../core/data/contracts';
+import type { HistoryDataSource } from '../../core/data/data_sources';
+import { createRouter, type Router } from '../../core/router';
+
+export type HistoryViewModel =
+  | { kind: 'redirect_onboarding'; redirectTo: string }
+  | { kind: 'empty'; portfolioId: string; emptyState: EmptyState }
+  | {
+      kind: 'ready';
+      portfolioId: string;
+      snapshots: HistorySnapshotsReadyData['snapshots'];
+      timelineItems: HistoryTimelineReadyData['items'];
+      targets: {
+        openPortfolio: { pathname: string };
+        openRadar: { pathname: string };
+      };
+    }
+  | { kind: 'error'; code?: string; message?: string };
+
+export interface HistoryControllerResult {
+  snapshots: ApiHistorySnapshotsEnvelope;
+  timeline: ApiHistoryTimelineEnvelope;
+  viewModel: HistoryViewModel;
+}
+
+export interface HistoryController {
+  load(input?: { limit?: number }): Promise<HistoryControllerResult>;
+}
+
+/**
+ * Historico: snapshots + timeline/eventos de forma util, coerente com a Home/Radar.
+ * Controller headless centraliza os dois endpoints.
+ */
+export function createHistoryController(input: { history: HistoryDataSource; router?: Router }): HistoryController {
+  const history = input.history;
+  const router = input.router ?? createRouter();
+
+  return {
+    async load(opts) {
+      const [snapshots, timeline] = await Promise.all([
+        history.getHistorySnapshots(opts),
+        history.getHistoryTimeline(opts)
+      ]);
+
+      if (!snapshots.ok) return { snapshots, timeline, viewModel: { kind: 'error', code: snapshots.error.code, message: snapshots.error.message } };
+      if (!timeline.ok) return { snapshots, timeline, viewModel: { kind: 'error', code: timeline.error.code, message: timeline.error.message } };
+
+      const sData = snapshots.data as HistorySnapshotsData;
+      const tData = timeline.data as HistoryTimelineData;
+
+      if ('screenState' in sData && sData.screenState === 'redirect_onboarding') {
+        return { snapshots, timeline, viewModel: { kind: 'redirect_onboarding', redirectTo: sData.redirectTo || '/onboarding' } };
+      }
+
+      if ('screenState' in tData && tData.screenState === 'redirect_onboarding') {
+        return { snapshots, timeline, viewModel: { kind: 'redirect_onboarding', redirectTo: tData.redirectTo || '/onboarding' } };
+      }
+
+      if (sData.screenState === 'empty' || tData.screenState === 'empty') {
+        const emptyState = (sData.screenState === 'empty'
+          ? (sData as HistorySnapshotsEmptyData).emptyState
+          : (tData as HistoryTimelineEmptyData).emptyState);
+        const portfolioId = sData.portfolioId;
+        return { snapshots, timeline, viewModel: { kind: 'empty', portfolioId, emptyState } };
+      }
+
+      const sReady = sData as HistorySnapshotsReadyData;
+      const tReady = tData as HistoryTimelineReadyData;
+      return {
+        snapshots,
+        timeline,
+        viewModel: {
+          kind: 'ready',
+          portfolioId: sReady.portfolioId,
+          snapshots: sReady.snapshots,
+          timelineItems: tReady.items,
+          targets: {
+            openPortfolio: { pathname: router.build({ id: 'portfolio' }) },
+            openRadar: { pathname: router.build({ id: 'radar' }) }
+          }
+        }
+      };
+    }
+  };
+}


### PR DESCRIPTION
Atende #214 (TEC-045) e #240 (E2E-021) no pps/web (sem layout).\n\n- eatures/analysis: controller headless do Radar (GET /v1/analysis) com targets validados\n- eatures/history: controller headless que consolida snapshots + timeline\n- eatures/consistency: report headless para comparar Home/Radar/Carteira (score/problema/acao) e sinalizar mismatch\n\nObjetivo: integrar telas com backend novo sem duplicar logica e garantir produto coerente.