### PR TITLE
Web: empty states com CTA valido (router-aware)

### DIFF
--- a/apps/web/src/core/view_models/empty_state.ts
+++ b/apps/web/src/core/view_models/empty_state.ts
@@ -1,0 +1,18 @@
+import type { EmptyState } from '../data/contracts';
+import { tryParseRoute, type AppRoute } from '../router';
+
+export type EmptyStateViewModel = EmptyState & {
+  targetRoute: AppRoute | null;
+};
+
+/**
+ * Garante que o CTA de um estado vazio aponta para uma rota valida do app.
+ * Nao muda o texto; apenas resolve/valida target.
+ */
+export function toEmptyStateViewModel(input: EmptyState): EmptyStateViewModel {
+  return {
+    ...input,
+    targetRoute: input.target ? tryParseRoute({ pathname: input.target }) : null
+  };
+}
+

--- a/apps/web/src/core/view_models/index.ts
+++ b/apps/web/src/core/view_models/index.ts
@@ -1,0 +1,2 @@
+export * from './empty_state';
+

--- a/apps/web/src/features/analysis/analysis_controller.ts
+++ b/apps/web/src/features/analysis/analysis_controller.ts
@@ -1,10 +1,11 @@
 import type { AnalysisData, ApiAnalysisEnvelope, AnalysisPendingData, AnalysisReadyData } from '../../core/data/contracts';
 import type { AnalysisDataSource } from '../../core/data/data_sources';
 import { createRouter, tryParseRoute, type Router } from '../../core/router';
+import { toEmptyStateViewModel, type EmptyStateViewModel } from '../../core/view_models/empty_state';
 
 export type AnalysisViewModel =
   | { kind: 'redirect_onboarding'; redirectTo: string }
-  | { kind: 'pending'; portfolioId: string; pendingState: AnalysisPendingData['pendingState'] }
+  | { kind: 'pending'; portfolioId: string; pendingState: EmptyStateViewModel }
   | {
       kind: 'ready';
       portfolioId: string;
@@ -50,7 +51,10 @@ export function createAnalysisController(input: { analysis: AnalysisDataSource; 
       }
 
       if ('screenState' in data && data.screenState === 'pending') {
-        return { envelope, viewModel: { kind: 'pending', portfolioId: data.portfolioId, pendingState: data.pendingState } };
+        return {
+          envelope,
+          viewModel: { kind: 'pending', portfolioId: data.portfolioId, pendingState: toEmptyStateViewModel(data.pendingState) }
+        };
       }
 
       // ready

--- a/apps/web/src/features/history/history_controller.ts
+++ b/apps/web/src/features/history/history_controller.ts
@@ -11,10 +11,11 @@ import type {
 } from '../../core/data/contracts';
 import type { HistoryDataSource } from '../../core/data/data_sources';
 import { createRouter, type Router } from '../../core/router';
+import { toEmptyStateViewModel, type EmptyStateViewModel } from '../../core/view_models/empty_state';
 
 export type HistoryViewModel =
   | { kind: 'redirect_onboarding'; redirectTo: string }
-  | { kind: 'empty'; portfolioId: string; emptyState: EmptyState }
+  | { kind: 'empty'; portfolioId: string; emptyState: EmptyStateViewModel }
   | {
       kind: 'ready';
       portfolioId: string;
@@ -71,7 +72,7 @@ export function createHistoryController(input: { history: HistoryDataSource; rou
           ? (sData as HistorySnapshotsEmptyData).emptyState
           : (tData as HistoryTimelineEmptyData).emptyState);
         const portfolioId = sData.portfolioId;
-        return { snapshots, timeline, viewModel: { kind: 'empty', portfolioId, emptyState } };
+        return { snapshots, timeline, viewModel: { kind: 'empty', portfolioId, emptyState: toEmptyStateViewModel(emptyState) } };
       }
 
       const sReady = sData as HistorySnapshotsReadyData;

--- a/apps/web/src/features/home/home_controller.ts
+++ b/apps/web/src/features/home/home_controller.ts
@@ -1,4 +1,4 @@
-import type { ApiDashboardHomeEnvelope, DashboardHomeData, ScreenStateRedirect } from '../../core/data/contracts';
+import type { ApiDashboardHomeEnvelope, DashboardHomeData, DashboardHomeEmptyData, ScreenStateRedirect } from '../../core/data/contracts';
 import type { DashboardDataSource } from '../../core/data/data_sources';
 import { tryParseRoute, type AppRoute } from '../../core/router';
 
@@ -52,6 +52,15 @@ function resolveNav(data: DashboardHomeData): HomeNavigationTargets {
 
   const targets: HomeNavigationTargets = {};
 
+  if (data.screenState === 'empty') {
+    const empty = data as DashboardHomeEmptyData;
+    const pathname = empty.emptyState.target;
+    const route = tryParseRoute({ pathname });
+    if (route) {
+      targets.primaryAction = { label: empty.emptyState.ctaLabel, pathname, route };
+    }
+  }
+
   // CTA principal vem do backend; valida antes de expor.
   if ('primaryAction' in data && data.primaryAction?.target) {
     const pathname = data.primaryAction.target;
@@ -80,4 +89,3 @@ function resolveNav(data: DashboardHomeData): HomeNavigationTargets {
 
   return targets;
 }
-

--- a/apps/web/src/features/portfolio/portfolio_controller.ts
+++ b/apps/web/src/features/portfolio/portfolio_controller.ts
@@ -8,6 +8,7 @@ import type {
 } from '../../core/data/contracts';
 import type { PortfolioDataSource } from '../../core/data/data_sources';
 import { createRouter, type Router } from '../../core/router';
+import { toEmptyStateViewModel, type EmptyStateViewModel } from '../../core/view_models/empty_state';
 
 export type PortfolioLocalFilters = {
   categoryKey?: string;
@@ -42,7 +43,7 @@ export type PortfolioReadyViewModel = {
 export type PortfolioEmptyViewModel = {
   kind: 'empty';
   portfolioId: string;
-  emptyState: PortfolioDataEmpty['emptyState'];
+  emptyState: EmptyStateViewModel;
 };
 
 export type PortfolioRedirectViewModel = {
@@ -104,7 +105,7 @@ function buildViewModel(data: PortfolioData, query: PortfolioQuery, router: Rout
   }
 
   if (data.screenState === 'empty') {
-    return { kind: 'empty', portfolioId: data.portfolioId, emptyState: data.emptyState };
+    return { kind: 'empty', portfolioId: data.portfolioId, emptyState: toEmptyStateViewModel(data.emptyState) };
   }
 
   // ready
@@ -161,4 +162,3 @@ function buildCategorySummaries(groups: PortfolioGroup[], totalEquity: number): 
 function round2(n: number): number {
   return Math.round(n * 100) / 100;
 }
-


### PR DESCRIPTION
Atende #237 (E2E-018) no pps/web (sem layout).\n\n- core/view_models: 	oEmptyStateViewModel resolve/valida EmptyState.target contra o router\n- Controllers (home/portfolio/history/analysis): expõem empty/pending com 	argetRoute (evita CTA quebrado e vazio com cara de erro)\n\nObjetivo: sempre existir proximo passo valido quando faltar dado.