### PR TITLE
Web: loading/feedback padronizado nos controllers (E2E-019)

### DIFF
--- a/apps/web/src/core/ops/index.ts
+++ b/apps/web/src/core/ops/index.ts
@@ -1,0 +1,2 @@
+export * from './load_state';
+

--- a/apps/web/src/core/ops/load_state.ts
+++ b/apps/web/src/core/ops/load_state.ts
@@ -1,0 +1,25 @@
+export type LoadPhase = 'idle' | 'loading' | 'success' | 'error';
+
+export type OperationFeedback = {
+  phase: LoadPhase;
+  label: string;
+  detail?: string;
+  /**
+   * Quando houver polling/steps, permite indicar "o que esta acontecendo" sem layout.
+   * 0..100 quando fizer sentido.
+   */
+  progressPct?: number;
+};
+
+export function loading(label: string, detail?: string): OperationFeedback {
+  return { phase: 'loading', label, detail };
+}
+
+export function success(label: string, detail?: string): OperationFeedback {
+  return { phase: 'success', label, detail };
+}
+
+export function error(label: string, detail?: string): OperationFeedback {
+  return { phase: 'error', label, detail };
+}
+

--- a/apps/web/src/features/analysis/analysis_controller.ts
+++ b/apps/web/src/features/analysis/analysis_controller.ts
@@ -2,6 +2,8 @@ import type { AnalysisData, ApiAnalysisEnvelope, AnalysisPendingData, AnalysisRe
 import type { AnalysisDataSource } from '../../core/data/data_sources';
 import { createRouter, tryParseRoute, type Router } from '../../core/router';
 import { toEmptyStateViewModel, type EmptyStateViewModel } from '../../core/view_models/empty_state';
+import type { OperationFeedback } from '../../core/ops/load_state';
+import { loading } from '../../core/ops/load_state';
 
 export type AnalysisViewModel =
   | { kind: 'redirect_onboarding'; redirectTo: string }
@@ -26,6 +28,7 @@ export type AnalysisViewModel =
 export interface AnalysisControllerResult {
   envelope: ApiAnalysisEnvelope;
   viewModel: AnalysisViewModel;
+  loadingFeedback: OperationFeedback;
 }
 
 export interface AnalysisController {
@@ -39,21 +42,23 @@ export interface AnalysisController {
 export function createAnalysisController(input: { analysis: AnalysisDataSource; router?: Router }): AnalysisController {
   const analysis = input.analysis;
   const router = input.router ?? createRouter();
+  const loadingFeedback = loading('Carregando Radar', 'Gerando/recuperando analise e score.');
 
   return {
     async load() {
       const envelope = await analysis.getAnalysis();
-      if (!envelope.ok) return { envelope, viewModel: { kind: 'error', code: envelope.error.code, message: envelope.error.message } };
+      if (!envelope.ok) return { envelope, viewModel: { kind: 'error', code: envelope.error.code, message: envelope.error.message }, loadingFeedback };
 
       const data = envelope.data as AnalysisData;
       if ('screenState' in data && data.screenState === 'redirect_onboarding') {
-        return { envelope, viewModel: { kind: 'redirect_onboarding', redirectTo: data.redirectTo || '/onboarding' } };
+        return { envelope, viewModel: { kind: 'redirect_onboarding', redirectTo: data.redirectTo || '/onboarding' }, loadingFeedback };
       }
 
       if ('screenState' in data && data.screenState === 'pending') {
         return {
           envelope,
-          viewModel: { kind: 'pending', portfolioId: data.portfolioId, pendingState: toEmptyStateViewModel(data.pendingState) }
+          viewModel: { kind: 'pending', portfolioId: data.portfolioId, pendingState: toEmptyStateViewModel(data.pendingState) },
+          loadingFeedback
         };
       }
 
@@ -64,6 +69,7 @@ export function createAnalysisController(input: { analysis: AnalysisDataSource; 
 
       return {
         envelope,
+        loadingFeedback,
         viewModel: {
           kind: 'ready',
           portfolioId: ready.portfolioId,

--- a/apps/web/src/features/history/history_controller.ts
+++ b/apps/web/src/features/history/history_controller.ts
@@ -12,6 +12,8 @@ import type {
 import type { HistoryDataSource } from '../../core/data/data_sources';
 import { createRouter, type Router } from '../../core/router';
 import { toEmptyStateViewModel, type EmptyStateViewModel } from '../../core/view_models/empty_state';
+import type { OperationFeedback } from '../../core/ops/load_state';
+import { loading } from '../../core/ops/load_state';
 
 export type HistoryViewModel =
   | { kind: 'redirect_onboarding'; redirectTo: string }
@@ -32,6 +34,7 @@ export interface HistoryControllerResult {
   snapshots: ApiHistorySnapshotsEnvelope;
   timeline: ApiHistoryTimelineEnvelope;
   viewModel: HistoryViewModel;
+  loadingFeedback: OperationFeedback;
 }
 
 export interface HistoryController {
@@ -45,6 +48,7 @@ export interface HistoryController {
 export function createHistoryController(input: { history: HistoryDataSource; router?: Router }): HistoryController {
   const history = input.history;
   const router = input.router ?? createRouter();
+  const loadingFeedback = loading('Carregando Historico', 'Buscando snapshots e eventos.');
 
   return {
     async load(opts) {
@@ -53,18 +57,18 @@ export function createHistoryController(input: { history: HistoryDataSource; rou
         history.getHistoryTimeline(opts)
       ]);
 
-      if (!snapshots.ok) return { snapshots, timeline, viewModel: { kind: 'error', code: snapshots.error.code, message: snapshots.error.message } };
-      if (!timeline.ok) return { snapshots, timeline, viewModel: { kind: 'error', code: timeline.error.code, message: timeline.error.message } };
+      if (!snapshots.ok) return { snapshots, timeline, viewModel: { kind: 'error', code: snapshots.error.code, message: snapshots.error.message }, loadingFeedback };
+      if (!timeline.ok) return { snapshots, timeline, viewModel: { kind: 'error', code: timeline.error.code, message: timeline.error.message }, loadingFeedback };
 
       const sData = snapshots.data as HistorySnapshotsData;
       const tData = timeline.data as HistoryTimelineData;
 
       if ('screenState' in sData && sData.screenState === 'redirect_onboarding') {
-        return { snapshots, timeline, viewModel: { kind: 'redirect_onboarding', redirectTo: sData.redirectTo || '/onboarding' } };
+        return { snapshots, timeline, viewModel: { kind: 'redirect_onboarding', redirectTo: sData.redirectTo || '/onboarding' }, loadingFeedback };
       }
 
       if ('screenState' in tData && tData.screenState === 'redirect_onboarding') {
-        return { snapshots, timeline, viewModel: { kind: 'redirect_onboarding', redirectTo: tData.redirectTo || '/onboarding' } };
+        return { snapshots, timeline, viewModel: { kind: 'redirect_onboarding', redirectTo: tData.redirectTo || '/onboarding' }, loadingFeedback };
       }
 
       if (sData.screenState === 'empty' || tData.screenState === 'empty') {
@@ -72,7 +76,7 @@ export function createHistoryController(input: { history: HistoryDataSource; rou
           ? (sData as HistorySnapshotsEmptyData).emptyState
           : (tData as HistoryTimelineEmptyData).emptyState);
         const portfolioId = sData.portfolioId;
-        return { snapshots, timeline, viewModel: { kind: 'empty', portfolioId, emptyState: toEmptyStateViewModel(emptyState) } };
+        return { snapshots, timeline, viewModel: { kind: 'empty', portfolioId, emptyState: toEmptyStateViewModel(emptyState) }, loadingFeedback };
       }
 
       const sReady = sData as HistorySnapshotsReadyData;
@@ -80,6 +84,7 @@ export function createHistoryController(input: { history: HistoryDataSource; rou
       return {
         snapshots,
         timeline,
+        loadingFeedback,
         viewModel: {
           kind: 'ready',
           portfolioId: sReady.portfolioId,

--- a/apps/web/src/features/home/home_controller.ts
+++ b/apps/web/src/features/home/home_controller.ts
@@ -1,6 +1,8 @@
 import type { ApiDashboardHomeEnvelope, DashboardHomeData, DashboardHomeEmptyData, ScreenStateRedirect } from '../../core/data/contracts';
 import type { DashboardDataSource } from '../../core/data/data_sources';
 import { tryParseRoute, type AppRoute } from '../../core/router';
+import type { OperationFeedback } from '../../core/ops/load_state';
+import { loading } from '../../core/ops/load_state';
 
 export interface HomeNavigationTargets {
   primaryAction?: { label: string; pathname: string; route: AppRoute };
@@ -12,6 +14,7 @@ export interface HomeNavigationTargets {
 export interface HomeControllerResult {
   envelope: ApiDashboardHomeEnvelope;
   nav: HomeNavigationTargets;
+  loadingFeedback: OperationFeedback;
 }
 
 export interface HomeController {
@@ -25,14 +28,15 @@ export interface HomeController {
  */
 export function createHomeController(input: { dashboard: DashboardDataSource }): HomeController {
   const dashboard = input.dashboard;
+  const loadingFeedback = loading('Carregando Home', 'Consolidando carteira e recomendacao.');
 
   return {
     async load() {
       const envelope = await dashboard.getDashboardHome();
-      if (!envelope.ok) return { envelope, nav: {} };
+      if (!envelope.ok) return { envelope, nav: {}, loadingFeedback };
 
       const nav = resolveNav(envelope.data);
-      return { envelope, nav };
+      return { envelope, nav, loadingFeedback };
     }
   };
 }

--- a/apps/web/src/features/portfolio/portfolio_controller.ts
+++ b/apps/web/src/features/portfolio/portfolio_controller.ts
@@ -9,6 +9,8 @@ import type {
 import type { PortfolioDataSource } from '../../core/data/data_sources';
 import { createRouter, type Router } from '../../core/router';
 import { toEmptyStateViewModel, type EmptyStateViewModel } from '../../core/view_models/empty_state';
+import type { OperationFeedback } from '../../core/ops/load_state';
+import { loading } from '../../core/ops/load_state';
 
 export type PortfolioLocalFilters = {
   categoryKey?: string;
@@ -66,6 +68,7 @@ export type PortfolioViewModel =
 export interface PortfolioControllerResult {
   envelope: ApiPortfolioEnvelope;
   viewModel: PortfolioViewModel;
+  loadingFeedback: OperationFeedback;
 }
 
 export interface PortfolioController {
@@ -81,6 +84,7 @@ export interface PortfolioController {
 export function createPortfolioController(input: { portfolio: PortfolioDataSource; router?: Router }): PortfolioController {
   const portfolio = input.portfolio;
   const router = input.router ?? createRouter();
+  const loadingFeedback = loading('Carregando Carteira', 'Lendo posicoes e agrupando por categoria.');
 
   return {
     async load(query) {
@@ -89,12 +93,13 @@ export function createPortfolioController(input: { portfolio: PortfolioDataSourc
       if (!envelope.ok) {
         return {
           envelope,
-          viewModel: { kind: 'error', code: envelope.error.code, message: envelope.error.message }
+          viewModel: { kind: 'error', code: envelope.error.code, message: envelope.error.message },
+          loadingFeedback
         };
       }
 
       const viewModel = buildViewModel(envelope.data, query ?? {}, router);
-      return { envelope, viewModel };
+      return { envelope, viewModel, loadingFeedback };
     }
   };
 }


### PR DESCRIPTION
Atende #238 (E2E-019) no pps/web (sem layout).\n\n- core/ops: OperationFeedback (idle/loading/success/error) + helpers\n- Controllers headless expõem loadingFeedback (texto para cenarios lentos)\n- imports_controller expõe eedback por etapa (start/preview/commit) para o usuario entender o que esta sendo processado\n\nObjetivo: reduzir sensacao de travamento e dar previsibilidade para a UI sem duplicar logica.