### PR TITLE
Web: erros recuperaveis (catalogo) + fault injection (E2E-020)

### DIFF
--- a/apps/web/src/core/data/index.ts
+++ b/apps/web/src/core/data/index.ts
@@ -2,4 +2,5 @@ export * from './types';
 export * from './contracts';
 export * from './data_sources';
 export * from './data_source_factory';
+export * from './providers/fault_injection_provider';
 

--- a/apps/web/src/core/data/providers/fault_injection_provider.ts
+++ b/apps/web/src/core/data/providers/fault_injection_provider.ts
@@ -1,0 +1,124 @@
+import type { AppDataSources } from '../data_sources';
+import type { ApiEnvelopeError, ApiMeta } from '../types';
+
+export type FaultKey =
+  | 'dashboard.home'
+  | 'portfolio.get'
+  | 'analysis.get'
+  | 'history.snapshots'
+  | 'history.timeline'
+  | 'holding_detail.get'
+  | 'profile.get'
+  | 'profile.put'
+  | 'imports.start'
+  | 'imports.preview'
+  | 'imports.commit';
+
+export type FaultSpec = {
+  code: string;
+  message: string;
+  once?: boolean;
+  details?: Record<string, unknown>;
+};
+
+export type FaultConfig = Partial<Record<FaultKey, FaultSpec>>;
+
+/**
+ * Wrapper de data sources para simular falhas sem depender de trocar mocks.
+ * Usado para E2E-020 (mensagens recuperaveis) e para validar UX em casos de erro.
+ */
+export function withFaultInjection(inner: AppDataSources, faults: FaultConfig): AppDataSources {
+  const shouldFail = (key: FaultKey): FaultSpec | null => {
+    const spec = faults[key];
+    if (!spec) return null;
+    if (spec.once) delete faults[key];
+    return spec;
+  };
+
+  const fail = (spec: FaultSpec): ApiEnvelopeError => ({
+    ok: false,
+    meta: makeMeta(),
+    error: { code: spec.code, message: spec.message, details: spec.details }
+  });
+
+  return {
+    dashboard: {
+      async getDashboardHome() {
+        const spec = shouldFail('dashboard.home');
+        if (spec) return fail(spec);
+        return await inner.dashboard.getDashboardHome();
+      }
+    },
+    analysis: {
+      async getAnalysis() {
+        const spec = shouldFail('analysis.get');
+        if (spec) return fail(spec);
+        return await inner.analysis.getAnalysis();
+      }
+    },
+    history: {
+      async getHistorySnapshots(input) {
+        const spec = shouldFail('history.snapshots');
+        if (spec) return fail(spec);
+        return await inner.history.getHistorySnapshots(input);
+      },
+      async getHistoryTimeline(input) {
+        const spec = shouldFail('history.timeline');
+        if (spec) return fail(spec);
+        return await inner.history.getHistoryTimeline(input);
+      }
+    },
+    portfolio: {
+      async getPortfolio(input) {
+        const spec = shouldFail('portfolio.get');
+        if (spec) return fail(spec);
+        return await inner.portfolio.getPortfolio(input);
+      }
+    },
+    holdingDetail: {
+      async getHoldingDetail(input) {
+        const spec = shouldFail('holding_detail.get');
+        if (spec) return fail(spec);
+        return await inner.holdingDetail.getHoldingDetail(input);
+      }
+    },
+    profile: {
+      async getProfileContext() {
+        const spec = shouldFail('profile.get');
+        if (spec) return fail(spec);
+        return await inner.profile.getProfileContext();
+      },
+      async putProfileContext(input) {
+        const spec = shouldFail('profile.put');
+        if (spec) return fail(spec);
+        return await inner.profile.putProfileContext(input);
+      }
+    },
+    imports: {
+      async startImport(input) {
+        const spec = shouldFail('imports.start');
+        if (spec) return fail(spec);
+        return await inner.imports.startImport(input);
+      },
+      async getImportPreview(input) {
+        const spec = shouldFail('imports.preview');
+        if (spec) return fail(spec);
+        return await inner.imports.getImportPreview(input);
+      },
+      async commitImport(input) {
+        const spec = shouldFail('imports.commit');
+        if (spec) return fail(spec);
+        return await inner.imports.commitImport(input);
+      }
+    }
+  };
+}
+
+function makeMeta(): ApiMeta {
+  return {
+    requestId: `req_fault_${Math.random().toString(16).slice(2)}`,
+    timestamp: new Date().toISOString(),
+    version: 'v1'
+  };
+}
+

--- a/apps/web/src/core/ops/error_catalog.ts
+++ b/apps/web/src/core/ops/error_catalog.ts
@@ -1,0 +1,79 @@
+import type { ApiError } from '../data/types';
+import type { OperationFeedback } from './load_state';
+import { error as errorFeedback } from './load_state';
+
+export type RetryHint =
+  | { kind: 'retry'; label: string }
+  | { kind: 'go_to'; label: string; pathname: string }
+  | { kind: 'none' };
+
+export type UserFacingError = {
+  title: string;
+  message: string;
+  retry: RetryHint;
+};
+
+/**
+ * Mapeia `error.code` para mensagens humanas e recuperaveis.
+ * Regra: nunca vazar stacktrace nem mensagem crua como primeira opcao.
+ */
+export function toUserFacingError(err: ApiError, context: { area: 'home' | 'history' | 'imports' | 'profile' | 'portfolio' | 'analysis' | 'holding_detail' }): UserFacingError {
+  switch (err.code) {
+    case 'unauthorized':
+      return {
+        title: 'Sessao expirada',
+        message: 'Sua sessao parece ter expirado. Entre novamente para continuar.',
+        retry: { kind: 'go_to', label: 'Ir para login', pathname: '/auth/login' }
+      };
+    case 'redirect_onboarding':
+      return {
+        title: 'Falta completar o onboarding',
+        message: 'Antes de continuar, precisamos completar seu contexto financeiro.',
+        retry: { kind: 'go_to', label: 'Completar onboarding', pathname: '/onboarding' }
+      };
+    case 'preview_not_consistent':
+      return {
+        title: 'Preview com pendencias',
+        message: 'Revise os itens invalidos ou em conflito antes de confirmar o commit.',
+        retry: { kind: 'retry', label: 'Voltar ao preview' }
+      };
+    case 'holding_not_found':
+      return {
+        title: 'Ativo nao encontrado',
+        message: 'Nao conseguimos abrir esse ativo. Ele pode ter sido removido ou alterado.',
+        retry: { kind: 'go_to', label: 'Voltar para a carteira', pathname: '/portfolio' }
+      };
+    default:
+      return {
+        title: 'Algo falhou',
+        message: defaultMessage(context.area),
+        retry: { kind: 'retry', label: 'Tentar novamente' }
+      };
+  }
+}
+
+export function toErrorFeedback(err: ApiError, context: { area: 'home' | 'history' | 'imports' | 'profile' | 'portfolio' | 'analysis' | 'holding_detail' }): OperationFeedback {
+  const user = toUserFacingError(err, context);
+  return errorFeedback(user.title, user.message);
+}
+
+function defaultMessage(area: 'home' | 'history' | 'imports' | 'profile' | 'portfolio' | 'analysis' | 'holding_detail'): string {
+  switch (area) {
+    case 'home':
+      return 'Nao conseguimos carregar sua Home agora. Tente novamente em instantes.';
+    case 'history':
+      return 'Nao conseguimos carregar seu historico agora. Tente novamente em instantes.';
+    case 'imports':
+      return 'Nao conseguimos processar sua importacao agora. Tente novamente em instantes.';
+    case 'portfolio':
+      return 'Nao conseguimos carregar sua carteira agora. Tente novamente em instantes.';
+    case 'analysis':
+      return 'Nao conseguimos carregar sua analise agora. Tente novamente em instantes.';
+    case 'holding_detail':
+      return 'Nao conseguimos carregar o detalhe agora. Tente novamente em instantes.';
+    case 'profile':
+      return 'Nao conseguimos carregar seu perfil agora. Tente novamente em instantes.';
+    default:
+      return 'Tente novamente em instantes.';
+  }
+}

--- a/apps/web/src/core/ops/index.ts
+++ b/apps/web/src/core/ops/index.ts
@@ -1,2 +1,2 @@
 export * from './load_state';
-
+export * from './error_catalog';

--- a/apps/web/src/features/analysis/analysis_controller.ts
+++ b/apps/web/src/features/analysis/analysis_controller.ts
@@ -4,6 +4,7 @@ import { createRouter, tryParseRoute, type Router } from '../../core/router';
 import { toEmptyStateViewModel, type EmptyStateViewModel } from '../../core/view_models/empty_state';
 import type { OperationFeedback } from '../../core/ops/load_state';
 import { loading } from '../../core/ops/load_state';
+import { toErrorFeedback } from '../../core/ops/error_catalog';
 
 export type AnalysisViewModel =
   | { kind: 'redirect_onboarding'; redirectTo: string }
@@ -29,6 +30,7 @@ export interface AnalysisControllerResult {
   envelope: ApiAnalysisEnvelope;
   viewModel: AnalysisViewModel;
   loadingFeedback: OperationFeedback;
+  errorFeedback?: OperationFeedback;
 }
 
 export interface AnalysisController {
@@ -47,7 +49,14 @@ export function createAnalysisController(input: { analysis: AnalysisDataSource; 
   return {
     async load() {
       const envelope = await analysis.getAnalysis();
-      if (!envelope.ok) return { envelope, viewModel: { kind: 'error', code: envelope.error.code, message: envelope.error.message }, loadingFeedback };
+      if (!envelope.ok) {
+        return {
+          envelope,
+          viewModel: { kind: 'error', code: envelope.error.code, message: envelope.error.message },
+          loadingFeedback,
+          errorFeedback: toErrorFeedback(envelope.error, { area: 'analysis' })
+        };
+      }
 
       const data = envelope.data as AnalysisData;
       if ('screenState' in data && data.screenState === 'redirect_onboarding') {

--- a/apps/web/src/features/history/history_controller.ts
+++ b/apps/web/src/features/history/history_controller.ts
@@ -14,6 +14,7 @@ import { createRouter, type Router } from '../../core/router';
 import { toEmptyStateViewModel, type EmptyStateViewModel } from '../../core/view_models/empty_state';
 import type { OperationFeedback } from '../../core/ops/load_state';
 import { loading } from '../../core/ops/load_state';
+import { toErrorFeedback } from '../../core/ops/error_catalog';
 
 export type HistoryViewModel =
   | { kind: 'redirect_onboarding'; redirectTo: string }
@@ -35,6 +36,7 @@ export interface HistoryControllerResult {
   timeline: ApiHistoryTimelineEnvelope;
   viewModel: HistoryViewModel;
   loadingFeedback: OperationFeedback;
+  errorFeedback?: OperationFeedback;
 }
 
 export interface HistoryController {
@@ -57,8 +59,24 @@ export function createHistoryController(input: { history: HistoryDataSource; rou
         history.getHistoryTimeline(opts)
       ]);
 
-      if (!snapshots.ok) return { snapshots, timeline, viewModel: { kind: 'error', code: snapshots.error.code, message: snapshots.error.message }, loadingFeedback };
-      if (!timeline.ok) return { snapshots, timeline, viewModel: { kind: 'error', code: timeline.error.code, message: timeline.error.message }, loadingFeedback };
+      if (!snapshots.ok) {
+        return {
+          snapshots,
+          timeline,
+          viewModel: { kind: 'error', code: snapshots.error.code, message: snapshots.error.message },
+          loadingFeedback,
+          errorFeedback: toErrorFeedback(snapshots.error, { area: 'history' })
+        };
+      }
+      if (!timeline.ok) {
+        return {
+          snapshots,
+          timeline,
+          viewModel: { kind: 'error', code: timeline.error.code, message: timeline.error.message },
+          loadingFeedback,
+          errorFeedback: toErrorFeedback(timeline.error, { area: 'history' })
+        };
+      }
 
       const sData = snapshots.data as HistorySnapshotsData;
       const tData = timeline.data as HistoryTimelineData;

--- a/apps/web/src/features/holding_detail/holding_detail_controller.ts
+++ b/apps/web/src/features/holding_detail/holding_detail_controller.ts
@@ -1,6 +1,9 @@
 import type { ApiHoldingDetailEnvelope, HoldingDetailData, HoldingDetailDataReady } from '../../core/data/contracts';
 import type { HoldingDetailDataSource } from '../../core/data/data_sources';
 import { createRouter, type Router } from '../../core/router';
+import type { OperationFeedback } from '../../core/ops/load_state';
+import { loading } from '../../core/ops/load_state';
+import { toErrorFeedback } from '../../core/ops/error_catalog';
 
 export type HoldingDetailViewModel =
   | { kind: 'redirect_onboarding'; redirectTo: string }
@@ -20,6 +23,8 @@ export type HoldingDetailViewModel =
 export interface HoldingDetailControllerResult {
   envelope: ApiHoldingDetailEnvelope;
   viewModel: HoldingDetailViewModel;
+  loadingFeedback: OperationFeedback;
+  errorFeedback?: OperationFeedback;
 }
 
 export interface HoldingDetailController {
@@ -35,22 +40,29 @@ export interface HoldingDetailController {
 export function createHoldingDetailController(input: { holdingDetail: HoldingDetailDataSource; router?: Router }): HoldingDetailController {
   const ds = input.holdingDetail;
   const router = input.router ?? createRouter();
+  const loadingFeedback = loading('Carregando detalhe', 'Buscando leitura e recomendacao do ativo.');
 
   return {
     async load(params) {
       const envelope = await ds.getHoldingDetail(params);
       if (!envelope.ok) {
-        return { envelope, viewModel: { kind: 'error', code: envelope.error.code, message: envelope.error.message } };
+        return {
+          envelope,
+          viewModel: { kind: 'error', code: envelope.error.code, message: envelope.error.message },
+          loadingFeedback,
+          errorFeedback: toErrorFeedback(envelope.error, { area: 'holding_detail' })
+        };
       }
 
       const data = envelope.data as HoldingDetailData;
       if ('screenState' in data && data.screenState === 'redirect_onboarding') {
-        return { envelope, viewModel: { kind: 'redirect_onboarding', redirectTo: data.redirectTo || '/onboarding' } };
+        return { envelope, viewModel: { kind: 'redirect_onboarding', redirectTo: data.redirectTo || '/onboarding' }, loadingFeedback };
       }
 
       const ready = data as HoldingDetailDataReady;
       return {
         envelope,
+        loadingFeedback,
         viewModel: {
           kind: 'ready',
           holding: ready.holding,

--- a/apps/web/src/features/home/home_controller.ts
+++ b/apps/web/src/features/home/home_controller.ts
@@ -3,6 +3,7 @@ import type { DashboardDataSource } from '../../core/data/data_sources';
 import { tryParseRoute, type AppRoute } from '../../core/router';
 import type { OperationFeedback } from '../../core/ops/load_state';
 import { loading } from '../../core/ops/load_state';
+import { toErrorFeedback } from '../../core/ops/error_catalog';
 
 export interface HomeNavigationTargets {
   primaryAction?: { label: string; pathname: string; route: AppRoute };
@@ -15,6 +16,7 @@ export interface HomeControllerResult {
   envelope: ApiDashboardHomeEnvelope;
   nav: HomeNavigationTargets;
   loadingFeedback: OperationFeedback;
+  errorFeedback?: OperationFeedback;
 }
 
 export interface HomeController {
@@ -33,7 +35,7 @@ export function createHomeController(input: { dashboard: DashboardDataSource }):
   return {
     async load() {
       const envelope = await dashboard.getDashboardHome();
-      if (!envelope.ok) return { envelope, nav: {}, loadingFeedback };
+      if (!envelope.ok) return { envelope, nav: {}, loadingFeedback, errorFeedback: toErrorFeedback(envelope.error, { area: 'home' }) };
 
       const nav = resolveNav(envelope.data);
       return { envelope, nav, loadingFeedback };

--- a/apps/web/src/features/portfolio/portfolio_controller.ts
+++ b/apps/web/src/features/portfolio/portfolio_controller.ts
@@ -11,6 +11,7 @@ import { createRouter, type Router } from '../../core/router';
 import { toEmptyStateViewModel, type EmptyStateViewModel } from '../../core/view_models/empty_state';
 import type { OperationFeedback } from '../../core/ops/load_state';
 import { loading } from '../../core/ops/load_state';
+import { toErrorFeedback } from '../../core/ops/error_catalog';
 
 export type PortfolioLocalFilters = {
   categoryKey?: string;
@@ -69,6 +70,7 @@ export interface PortfolioControllerResult {
   envelope: ApiPortfolioEnvelope;
   viewModel: PortfolioViewModel;
   loadingFeedback: OperationFeedback;
+  errorFeedback?: OperationFeedback;
 }
 
 export interface PortfolioController {
@@ -94,7 +96,8 @@ export function createPortfolioController(input: { portfolio: PortfolioDataSourc
         return {
           envelope,
           viewModel: { kind: 'error', code: envelope.error.code, message: envelope.error.message },
-          loadingFeedback
+          loadingFeedback,
+          errorFeedback: toErrorFeedback(envelope.error, { area: 'portfolio' })
         };
       }
 


### PR DESCRIPTION
Atende #239 (E2E-020) no pps/web (sem layout).\n\n- core/ops/error_catalog: mapeia rror.code -> titulo/mensagem humana (por area) e evita vazar texto tecnico cru\n- Controllers: expõem rrorFeedback padronizado em falhas de leitura e processamento\n- core/data/providers/fault_injection_provider: wrapper para simular falhas (home/history/imports/etc) sem trocar mocks\n\nObjetivo: mensagens claras + retry/proximo passo quando fizer sentido.