### PR TITLE
Web: fallback de dados externos (sem quebra)

### DIFF
--- a/apps/web/src/core/view_models/external_data.ts
+++ b/apps/web/src/core/view_models/external_data.ts
@@ -1,0 +1,41 @@
+export type ExternalDataBanner = {
+  kind: 'external_data';
+  severity: 'info' | 'warning';
+  title: string;
+  body: string;
+};
+
+export function bannerFromSourceWarning(sourceWarning: string | null | undefined): ExternalDataBanner | null {
+  if (!sourceWarning) return null;
+  return {
+    kind: 'external_data',
+    severity: 'info',
+    title: 'Dados externos indisponiveis',
+    body: sourceWarning
+  };
+}
+
+export function bannerFromQuotationStatus(input: { quotationStatus: string | null | undefined }): ExternalDataBanner | null {
+  const status = input.quotationStatus;
+  if (!status) return null;
+
+  // O contrato usa string; tratamos "priced" como caminho feliz.
+  if (status === 'priced') return null;
+
+  return {
+    kind: 'external_data',
+    severity: 'warning',
+    title: 'Cotacao indisponivel',
+    body: 'Alguns valores podem estar desatualizados por falta de referencia externa. A leitura principal continua valida.'
+  };
+}
+
+export function bannerFromMissingExternalLink(externalLink: string | null | undefined): ExternalDataBanner | null {
+  if (externalLink) return null;
+  return {
+    kind: 'external_data',
+    severity: 'info',
+    title: 'Link externo indisponivel',
+    body: 'Alguns detalhes externos podem nao aparecer agora. O nucleo do produto continua funcionando.'
+  };
+}

--- a/apps/web/src/core/view_models/index.ts
+++ b/apps/web/src/core/view_models/index.ts
@@ -1,2 +1,2 @@
 export * from './empty_state';
-
+export * from './external_data';

--- a/apps/web/src/features/holding_detail/holding_detail_controller.ts
+++ b/apps/web/src/features/holding_detail/holding_detail_controller.ts
@@ -4,6 +4,7 @@ import { createRouter, type Router } from '../../core/router';
 import type { OperationFeedback } from '../../core/ops/load_state';
 import { loading } from '../../core/ops/load_state';
 import { toErrorFeedback } from '../../core/ops/error_catalog';
+import { bannerFromMissingExternalLink, bannerFromQuotationStatus, type ExternalDataBanner } from '../../core/view_models/external_data';
 
 export type HoldingDetailViewModel =
   | { kind: 'redirect_onboarding'; redirectTo: string }
@@ -25,6 +26,7 @@ export interface HoldingDetailControllerResult {
   viewModel: HoldingDetailViewModel;
   loadingFeedback: OperationFeedback;
   errorFeedback?: OperationFeedback;
+  externalDataBanner?: ExternalDataBanner | null;
 }
 
 export interface HoldingDetailController {
@@ -60,9 +62,13 @@ export function createHoldingDetailController(input: { holdingDetail: HoldingDet
       }
 
       const ready = data as HoldingDetailDataReady;
+      const externalDataBanner =
+        bannerFromQuotationStatus({ quotationStatus: ready.holding.quotationStatus }) ??
+        bannerFromMissingExternalLink(ready.externalLink);
       return {
         envelope,
         loadingFeedback,
+        externalDataBanner,
         viewModel: {
           kind: 'ready',
           holding: ready.holding,

--- a/apps/web/src/features/home/home_controller.ts
+++ b/apps/web/src/features/home/home_controller.ts
@@ -4,6 +4,7 @@ import { tryParseRoute, type AppRoute } from '../../core/router';
 import type { OperationFeedback } from '../../core/ops/load_state';
 import { loading } from '../../core/ops/load_state';
 import { toErrorFeedback } from '../../core/ops/error_catalog';
+import { bannerFromSourceWarning, type ExternalDataBanner } from '../../core/view_models/external_data';
 
 export interface HomeNavigationTargets {
   primaryAction?: { label: string; pathname: string; route: AppRoute };
@@ -17,6 +18,7 @@ export interface HomeControllerResult {
   nav: HomeNavigationTargets;
   loadingFeedback: OperationFeedback;
   errorFeedback?: OperationFeedback;
+  externalDataBanner?: ExternalDataBanner | null;
 }
 
 export interface HomeController {
@@ -38,7 +40,9 @@ export function createHomeController(input: { dashboard: DashboardDataSource }):
       if (!envelope.ok) return { envelope, nav: {}, loadingFeedback, errorFeedback: toErrorFeedback(envelope.error, { area: 'home' }) };
 
       const nav = resolveNav(envelope.data);
-      return { envelope, nav, loadingFeedback };
+      const externalDataBanner =
+        envelope.data.screenState === 'ready' ? bannerFromSourceWarning((envelope.data as any).sourceWarning) : null;
+      return { envelope, nav, loadingFeedback, externalDataBanner };
     }
   };
 }

--- a/apps/web/src/features/portfolio/portfolio_controller.ts
+++ b/apps/web/src/features/portfolio/portfolio_controller.ts
@@ -12,6 +12,7 @@ import { toEmptyStateViewModel, type EmptyStateViewModel } from '../../core/view
 import type { OperationFeedback } from '../../core/ops/load_state';
 import { loading } from '../../core/ops/load_state';
 import { toErrorFeedback } from '../../core/ops/error_catalog';
+import { bannerFromQuotationStatus, type ExternalDataBanner } from '../../core/view_models/external_data';
 
 export type PortfolioLocalFilters = {
   categoryKey?: string;
@@ -71,6 +72,7 @@ export interface PortfolioControllerResult {
   viewModel: PortfolioViewModel;
   loadingFeedback: OperationFeedback;
   errorFeedback?: OperationFeedback;
+  externalDataBanner?: ExternalDataBanner | null;
 }
 
 export interface PortfolioController {
@@ -102,9 +104,16 @@ export function createPortfolioController(input: { portfolio: PortfolioDataSourc
       }
 
       const viewModel = buildViewModel(envelope.data, query ?? {}, router);
-      return { envelope, viewModel, loadingFeedback };
+      const externalDataBanner = inferExternalBanner(viewModel);
+      return { envelope, viewModel, loadingFeedback, externalDataBanner };
     }
   };
+}
+
+function inferExternalBanner(viewModel: PortfolioViewModel): ExternalDataBanner | null {
+  if (viewModel.kind !== 'ready') return null;
+  const hasDegraded = viewModel.holdings.some((h) => h.quotationStatus && h.quotationStatus !== 'priced');
+  return hasDegraded ? bannerFromQuotationStatus({ quotationStatus: 'degraded' }) : null;
 }
 
 function buildViewModel(data: PortfolioData, query: PortfolioQuery, router: Router): PortfolioViewModel {


### PR DESCRIPTION
Atende #243 (E2E-024) no pps/web (sem layout).\n\n- core/view_models/external_data: banners opcionais para ausencia/degradacao de enriquecimento externo\n- Controllers (home/portfolio/holding_detail): expõem xternalDataBanner quando sourceWarning existir, quotationStatus nao for priced ou xternalLink faltar\n\nObjetivo: nucleo continua operando; usuario entende ausencia de dado complementar sem travar.