### PR TITLE
TEC-035 (#204): dados externos (cache D1 + health status + enrichment opcional)

### DIFF
--- a/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/openapi.yaml
+++ b/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/openapi.yaml
@@ -349,6 +349,9 @@ components:
               type: string
             externalReferences:
               type: string
+              description: |
+                Complementary external references health. Must never block core flows.
+              enum: [disabled, degraded, ok]
 
     HomeEnvelope:
       allOf:

--- a/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/src/lib/external_references_service.ts
+++ b/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/src/lib/external_references_service.ts
@@ -1,0 +1,168 @@
+import type { Env } from '../types/env';
+import {
+  findFreshExternalReferenceCacheByKey,
+  upsertExternalReferenceCache,
+  getExternalReferencesCacheHealth
+} from '../repositories/external_reference_cache_repository';
+
+export type ExternalReferencesServiceStatus = 'disabled' | 'degraded' | 'ok';
+
+function isEnabledFlag(value: unknown): boolean {
+  const raw = typeof value === 'string' ? value.trim().toLowerCase() : '';
+  return raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on';
+}
+
+export async function getExternalReferencesServiceStatus(env: Env): Promise<ExternalReferencesServiceStatus> {
+  if (!isEnabledFlag(env.EXTERNAL_REFERENCES_ENABLED)) return 'disabled';
+
+  // Health must be cheap and must not depend on external network calls.
+  const health = await getExternalReferencesCacheHealth(env).catch(() => ({ lastOkAt: null, lastErrorAt: null }));
+  if (!health.lastOkAt) return 'degraded';
+
+  const lastOkMs = Date.parse(health.lastOkAt);
+  if (!Number.isFinite(lastOkMs)) return 'degraded';
+
+  // Consider "ok" when we had at least one successful refresh recently.
+  const maxAgeMs = 24 * 60 * 60 * 1000;
+  return Date.now() - lastOkMs <= maxAgeMs ? 'ok' : 'degraded';
+}
+
+export interface ExternalQuote {
+  price: number;
+  currency: string | null;
+  asOf: string | null;
+  source: string;
+}
+
+export async function getExternalQuoteForStockBvmf(env: Env, code: string): Promise<ExternalQuote | null> {
+  if (!isEnabledFlag(env.EXTERNAL_REFERENCES_ENABLED)) return null;
+  const normalized = (code || '').trim().toUpperCase();
+  if (!normalized) return null;
+
+  const now = new Date();
+  const nowIso = now.toISOString();
+  const cacheKey = `quote:stock:${normalized}:BVMF`;
+
+  const cached = await findFreshExternalReferenceCacheByKey(env, cacheKey, nowIso).catch(() => null);
+  if (cached?.status === 'ok') {
+    const parsed = safeJsonParse<Record<string, unknown>>(cached.value_json);
+    const price = coerceNumber(parsed?.price);
+    if (price != null) {
+      return {
+        price,
+        currency: typeof parsed?.currency === 'string' ? parsed.currency : null,
+        asOf: typeof parsed?.asOf === 'string' ? parsed.asOf : null,
+        source: cached.source
+      };
+    }
+  }
+
+  const fetched = await fetchQuoteFromBrapi(env, normalized);
+  const ttlOkMs = 15 * 60 * 1000;
+  const ttlErrMs = 2 * 60 * 1000;
+  const expiresAt = new Date(now.getTime() + (fetched ? ttlOkMs : ttlErrMs)).toISOString();
+
+  if (!fetched) {
+    await upsertExternalReferenceCache(env, {
+      cacheKey,
+      kind: 'quote',
+      source: 'brapi',
+      valueJson: JSON.stringify({ code: normalized }),
+      fetchedAt: nowIso,
+      expiresAt,
+      status: 'error',
+      errorMessage: 'quote_unavailable'
+    }).catch(() => {});
+    return null;
+  }
+
+  await upsertExternalReferenceCache(env, {
+    cacheKey,
+    kind: 'quote',
+    source: 'brapi',
+    valueJson: JSON.stringify({
+      code: normalized,
+      price: fetched.price,
+      currency: fetched.currency,
+      asOf: fetched.asOf
+    }),
+    fetchedAt: nowIso,
+    expiresAt,
+    status: 'ok',
+    errorMessage: null
+  }).catch(() => {});
+
+  return fetched;
+}
+
+async function fetchQuoteFromBrapi(env: Env, code: string): Promise<ExternalQuote | null> {
+  const base = (env.EXTERNAL_REFERENCES_BRAPI_BASE_URL || 'https://brapi.dev/api').replace(/\/+$/, '');
+  const token = (env.EXTERNAL_REFERENCES_BRAPI_TOKEN || '').trim();
+  const url = new URL(`${base}/quote/${encodeURIComponent(code)}`);
+  if (token) url.searchParams.set('token', token);
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
+  try {
+    const res = await fetch(url.toString(), {
+      method: 'GET',
+      headers: { accept: 'application/json' },
+      signal: controller.signal
+    });
+    if (!res.ok) return null;
+    const json = await res.json<any>().catch(() => null);
+    const first = pickFirstResult(json);
+    if (!first) return null;
+
+    const price =
+      coerceNumber(first.regularMarketPrice) ??
+      coerceNumber(first.price) ??
+      coerceNumber(first.lastPrice) ??
+      coerceNumber(first.close);
+    if (price == null) return null;
+
+    const asOf =
+      coerceIsoFromUnixSeconds(first.regularMarketTime) ??
+      (typeof first.updatedAt === 'string' ? first.updatedAt : null) ??
+      null;
+
+    const currency = typeof first.currency === 'string' ? first.currency : null;
+    return { price, currency, asOf, source: 'brapi' };
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function pickFirstResult(value: any): any | null {
+  if (!value || typeof value !== 'object') return null;
+  const results = (value.results ?? value.result ?? value.data) as unknown;
+  if (Array.isArray(results) && results.length) return results[0];
+  if (Array.isArray(value) && value.length) return value[0];
+  return null;
+}
+
+function safeJsonParse<T>(value: unknown): T | null {
+  if (typeof value !== 'string' || !value.trim()) return null;
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return null;
+  }
+}
+
+function coerceNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim() !== '' && !Number.isNaN(Number(value))) return Number(value);
+  return null;
+}
+
+function coerceIsoFromUnixSeconds(value: unknown): string | null {
+  const seconds = coerceNumber(value);
+  if (seconds == null) return null;
+  const ms = seconds * 1000;
+  const date = new Date(ms);
+  return Number.isFinite(date.getTime()) ? date.toISOString() : null;
+}
+

--- a/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/src/lib/holding_detail_service.ts
+++ b/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/src/lib/holding_detail_service.ts
@@ -1,6 +1,7 @@
 import type { Env } from '../types/env';
 import { ok, fail } from './http';
 import { hashToken } from './auth_crypto';
+import { getExternalQuoteForStockBvmf } from './external_references_service';
 import {
   findHoldingSessionStateByTokenHash,
   findHoldingDetailById,
@@ -39,7 +40,19 @@ export async function getHoldingDetailData(request: Request, env: Env, params: R
 
   const investedAmount = Number(holding.invested_amount || 0);
   const currentValue = Number(holding.current_amount || 0);
-  const currentPrice = holding.current_price == null ? null : Number(holding.current_price);
+  const storedCurrentPrice = holding.current_price == null ? null : Number(holding.current_price);
+  let currentPrice = storedCurrentPrice;
+  let sourceWarning: string | undefined;
+
+  // External quote is complementary: only used when we don't have current_price stored.
+  const normalizedType = (holding.asset_type_code || '').toUpperCase();
+  if (currentPrice == null && normalizedType === 'STOCK' && holding.code) {
+    const quote = await getExternalQuoteForStockBvmf(env, holding.code);
+    if (quote?.price != null) {
+      currentPrice = quote.price;
+      sourceWarning = 'Cotacao veio de fonte externa complementar.';
+    }
+  }
   const averagePrice = Number(holding.average_price || 0);
   const performanceValue = currentValue - investedAmount;
   const performancePct = investedAmount > 0 ? (performanceValue / investedAmount) * 100 : null;
@@ -74,7 +87,7 @@ export async function getHoldingDetailData(request: Request, env: Env, params: R
       performancePct,
       allocationPct,
       recommendation: recommendation.title,
-      statusLabel: currentPrice == null ? 'Sem cotacao atual' : 'Cotacao disponivel',
+      statusLabel: currentPrice == null ? 'Sem cotacao atual' : sourceWarning ? 'Cotacao externa' : 'Cotacao disponivel',
       quotationStatus: currentPrice == null ? 'missing_quote' : 'priced',
       notes: holding.notes || '',
       stopLoss: holding.stop_loss == null ? null : Number(holding.stop_loss),
@@ -86,7 +99,7 @@ export async function getHoldingDetailData(request: Request, env: Env, params: R
     recommendation,
     categoryContext,
     externalLink: buildExternalLink(holding.asset_type_code || '', holding.code || '')
-  });
+  }, sourceWarning);
 }
 
 function buildRanking(input: { allocationPct: number; performancePct: number | null; hasQuote: boolean }) {

--- a/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/src/lib/profile_context_service.ts
+++ b/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/src/lib/profile_context_service.ts
@@ -4,6 +4,7 @@ import { buildEntityId, hashToken } from './auth_crypto';
 import { recordOperationalEvent } from './operational_events_service';
 import { findSessionStateByTokenHash } from '../repositories/auth_session_repository';
 import { findProfileContextByUserId, upsertProfileContext } from '../repositories/profile_context_repository';
+import { getExternalReferencesServiceStatus } from './external_references_service';
 
 const AUTH_COOKIE_NAME = 'esquilo_session';
 const VALID_ONBOARDING_STEPS = ['goal', 'risk_quiz', 'income_horizon', 'platforms'];
@@ -15,6 +16,7 @@ export async function getProfileContextForOnboarding(request: Request, env: Env)
 
   const context = await findProfileContextByUserId(env, session.userId);
   const normalized = normalizeStoredContext(context);
+  const externalStatus = await getExternalReferencesServiceStatus(env);
 
   return ok(env.API_VERSION, {
     userId: session.userId,
@@ -27,7 +29,7 @@ export async function getProfileContextForOnboarding(request: Request, env: Env)
       apiVersion: env.API_VERSION,
       services: {
         d1: 'ok',
-        externalReferences: 'unknown'
+        externalReferences: externalStatus
       }
     }
   });

--- a/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/src/repositories/external_reference_cache_repository.ts
+++ b/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/src/repositories/external_reference_cache_repository.ts
@@ -1,0 +1,98 @@
+import type { Env } from '../types/env';
+import { d1 } from '../lib/d1';
+
+export interface ExternalReferenceCacheRow {
+  cache_key: string;
+  kind: string;
+  source: string;
+  value_json: string;
+  fetched_at: string;
+  expires_at: string;
+  status: 'ok' | 'error';
+  error_message: string | null;
+}
+
+export async function findFreshExternalReferenceCacheByKey(
+  env: Env,
+  cacheKey: string,
+  nowIso: string
+): Promise<ExternalReferenceCacheRow | null> {
+  return await d1(env).first<ExternalReferenceCacheRow>(
+    `SELECT
+       cache_key,
+       kind,
+       source,
+       value_json,
+       fetched_at,
+       expires_at,
+       status,
+       error_message
+     FROM external_reference_cache
+     WHERE cache_key = ?
+       AND expires_at > ?
+     LIMIT 1`,
+    [cacheKey, nowIso]
+  );
+}
+
+export async function upsertExternalReferenceCache(
+  env: Env,
+  input: {
+    cacheKey: string;
+    kind: string;
+    source: string;
+    valueJson: string;
+    fetchedAt: string;
+    expiresAt: string;
+    status: 'ok' | 'error';
+    errorMessage?: string | null;
+  }
+): Promise<void> {
+  await d1(env).run(
+    `INSERT INTO external_reference_cache (
+       cache_key,
+       kind,
+       source,
+       value_json,
+       fetched_at,
+       expires_at,
+       status,
+       error_message,
+       updated_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+     ON CONFLICT(cache_key) DO UPDATE SET
+       kind = excluded.kind,
+       source = excluded.source,
+       value_json = excluded.value_json,
+       fetched_at = excluded.fetched_at,
+       expires_at = excluded.expires_at,
+       status = excluded.status,
+       error_message = excluded.error_message,
+       updated_at = CURRENT_TIMESTAMP`,
+    [
+      input.cacheKey,
+      input.kind,
+      input.source,
+      input.valueJson,
+      input.fetchedAt,
+      input.expiresAt,
+      input.status,
+      input.errorMessage ?? null
+    ]
+  );
+}
+
+export async function getExternalReferencesCacheHealth(env: Env): Promise<{ lastOkAt: string | null; lastErrorAt: string | null }> {
+  const okRow = await d1(env).first<{ lastOkAt: string | null }>(
+    `SELECT MAX(fetched_at) AS lastOkAt
+     FROM external_reference_cache
+     WHERE status = 'ok'`
+  );
+  const errRow = await d1(env).first<{ lastErrorAt: string | null }>(
+    `SELECT MAX(fetched_at) AS lastErrorAt
+     FROM external_reference_cache
+     WHERE status = 'error'`
+  );
+  return { lastOkAt: okRow?.lastOkAt ?? null, lastErrorAt: errRow?.lastErrorAt ?? null };
+}
+

--- a/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/src/routes/health.ts
+++ b/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/src/routes/health.ts
@@ -1,9 +1,11 @@
 import type { Env } from '../types/env';
 import { ok, fail } from '../lib/http';
+import { getExternalReferencesServiceStatus } from '../lib/external_references_service';
 
 export async function getHealth(_request: Request, env: Env): Promise<Response> {
   try {
     await env.DB.prepare('SELECT 1 as ok').first();
+    const externalStatus = await getExternalReferencesServiceStatus(env);
 
     return ok(env.API_VERSION, {
       status: 'ok',
@@ -11,7 +13,7 @@ export async function getHealth(_request: Request, env: Env): Promise<Response> 
       apiVersion: env.API_VERSION,
       services: {
         d1: 'ok',
-        externalReferences: 'unknown'
+        externalReferences: externalStatus
       }
     });
   } catch (error) {

--- a/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/src/types/env.ts
+++ b/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/src/types/env.ts
@@ -12,4 +12,9 @@ export interface Env {
   APPS_SCRIPT_RECOVERY_SECRET?: string;
   OPENAI_API_KEY?: string;
   GEMINI_API_KEY?: string;
+
+  // Complementary external references (must never be required for core flows).
+  EXTERNAL_REFERENCES_ENABLED?: string;
+  EXTERNAL_REFERENCES_BRAPI_BASE_URL?: string;
+  EXTERNAL_REFERENCES_BRAPI_TOKEN?: string;
 }

--- a/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/wrangler.toml
+++ b/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/wrangler.toml
@@ -22,6 +22,8 @@ APP_ENV = "local"
 API_VERSION = "v1"
 # Vite dev server roda em porta diferente do wrangler dev — CORS necessário em local.
 CORS_ALLOWED_ORIGINS = "http://localhost:5173,http://localhost:5174"
+EXTERNAL_REFERENCES_ENABLED = "0"
+EXTERNAL_REFERENCES_BRAPI_BASE_URL = "https://brapi.dev/api"
 
 [[env.local.d1_databases]]
 binding = "DB"
@@ -34,6 +36,8 @@ name = "esquilo-invest-api-hml"
 [env.hml.vars]
 APP_ENV = "hml"
 API_VERSION = "v1"
+EXTERNAL_REFERENCES_ENABLED = "0"
+EXTERNAL_REFERENCES_BRAPI_BASE_URL = "https://brapi.dev/api"
 
 [[env.hml.d1_databases]]
 binding = "DB"
@@ -51,6 +55,8 @@ name = "esquilo-invest-api"
 [env.production.vars]
 APP_ENV = "production"
 API_VERSION = "v1"
+EXTERNAL_REFERENCES_ENABLED = "0"
+EXTERNAL_REFERENCES_BRAPI_BASE_URL = "https://brapi.dev/api"
 
 [[env.production.d1_databases]]
 binding = "DB"

--- a/database/d1/schema.sql
+++ b/database/d1/schema.sql
@@ -278,3 +278,22 @@ CREATE TABLE IF NOT EXISTS operational_events (
 CREATE INDEX IF NOT EXISTS idx_operational_events_user_id ON operational_events(user_id);
 CREATE INDEX IF NOT EXISTS idx_operational_events_portfolio_id ON operational_events(portfolio_id);
 CREATE INDEX IF NOT EXISTS idx_operational_events_occurred_at ON operational_events(occurred_at);
+
+-- Complementary external references (must never be required for core flows).
+-- Cache keys are stable strings (e.g. "quote:stock:ITSA4:BVMF").
+CREATE TABLE IF NOT EXISTS external_reference_cache (
+  cache_key TEXT PRIMARY KEY,
+  kind TEXT NOT NULL,
+  source TEXT NOT NULL,
+  value_json TEXT NOT NULL,
+  fetched_at TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'ok',
+  error_message TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_external_reference_cache_kind ON external_reference_cache(kind);
+CREATE INDEX IF NOT EXISTS idx_external_reference_cache_expires_at ON external_reference_cache(expires_at);
+CREATE INDEX IF NOT EXISTS idx_external_reference_cache_status ON external_reference_cache(status);

--- a/packages/contracts/health.md
+++ b/packages/contracts/health.md
@@ -15,8 +15,8 @@
     "status": "ok",
     "appEnv": "local|hml|prd",
     "services": {
-      "database": "ok",
-      "analysis": "ok"
+      "d1": "ok",
+      "externalReferences": "disabled|degraded|ok"
     }
   }
 }

--- a/packages/contracts/profile_context.md
+++ b/packages/contracts/profile_context.md
@@ -54,7 +54,7 @@ Headers:
     "status": "ok",
     "appEnv": "local",
     "apiVersion": "v1",
-    "services": { "d1": "ok", "externalReferences": "unknown" }
+    "services": { "d1": "ok", "externalReferences": "disabled|degraded|ok" }
   }
 }
 ```


### PR DESCRIPTION
Resolve #204\n\nO que entra\n- D1: tabela external_reference_cache (dados complementares; core nao depende)\n- Health/Profile: externalReferences = disabled|degraded|ok (sem chamada externa no health)\n- Holding detail: se current_price estiver ausente e for STOCK, tenta cotacao externa via cache/provedor e seta sourceWarning\n- OpenAPI + contracts atualizados\n\nNotas\n- Feature flag: EXTERNAL_REFERENCES_ENABLED (default 0)\n- Evita N+1: enrichment apenas no detalhe do ativo\n