### PR TITLE
Web: entrada sem friccao (onboarding leve + home preview)

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -4,6 +4,8 @@ import { createAppShell } from './app_shell';
 import { createViteJsonLoader } from './vite_json_loader';
 import type { DataSourceMode } from '../core/data/data_source_factory';
 import { SplashScreen } from '../features/splash/SplashScreen';
+import { OnboardingScreen } from '../features/onboarding/OnboardingScreen';
+import { HomeScreen } from '../features/home/HomeScreen';
 
 function getEnv(): AppEnv {
   const raw = String(import.meta.env.VITE_APP_ENV ?? 'local');
@@ -35,6 +37,7 @@ export function App(): JSX.Element {
   }, [env]);
 
   const state = useSyncExternalStore(shell.subscribe, shell.getState, shell.getState);
+  const dataSources = shell.getDataSources();
 
   useEffect(() => {
     const onPop = () => shell.navigateTo(window.location.pathname);
@@ -54,6 +57,26 @@ export function App(): JSX.Element {
       <SplashScreen
         onStart={() => navigate('/onboarding')}
         onSeeHowItWorks={() => navigate('/onboarding')}
+      />
+    );
+  }
+
+  if (state.route.id === 'onboarding') {
+    return (
+      <OnboardingScreen
+        dataSources={dataSources}
+        onDone={() => navigate('/home')}
+        onSkip={() => navigate('/home')}
+      />
+    );
+  }
+
+  if (state.route.id === 'home') {
+    return (
+      <HomeScreen
+        dataSources={dataSources}
+        onGoToOnboarding={() => navigate('/onboarding')}
+        onGoToPortfolio={() => navigate('/portfolio')}
       />
     );
   }

--- a/apps/web/src/app/app_shell.ts
+++ b/apps/web/src/app/app_shell.ts
@@ -1,5 +1,6 @@
 import type { AppEnv } from '../core/data';
 import { createDataSources, type DataSourceMode } from '../core/data';
+import type { AppDataSources } from '../core/data/data_sources';
 import type { JsonLoader } from '../core/data/types';
 import { createRouter, type RouterLocationLike } from '../core/router';
 import { createInitialAppState, createStore, type AppState } from '../core/state';
@@ -17,6 +18,7 @@ export interface AppShell {
   getState(): AppState;
   subscribe(listener: (s: AppState) => void): () => void;
   navigateTo(pathname: string): void;
+  getDataSources(): AppDataSources;
 }
 
 /**
@@ -28,13 +30,12 @@ export function createAppShell(config: AppShellConfig, location: RouterLocationL
   const initialRoute = router.parse(location);
 
   // A factory fica pronta para quando o app virar Node real; por enquanto isto só garante wiring consistente.
-  const dataSources = createDataSources({
+  const dataSources: AppDataSources = createDataSources({
     appEnv: config.env,
     mode: config.dataSources.mode,
     httpBaseUrl: config.dataSources.httpBaseUrl,
     mockLoader: config.dataSources.mockLoader
   });
-  void dataSources;
 
   const store = createStore<AppState>(createInitialAppState({ env: config.env, route: initialRoute }));
 
@@ -43,6 +44,9 @@ export function createAppShell(config: AppShellConfig, location: RouterLocationL
     subscribe: store.subscribe,
     navigateTo(pathname) {
       store.setState((s) => ({ ...s, route: router.parse({ pathname }) }));
+    },
+    getDataSources() {
+      return dataSources;
     }
   };
 }

--- a/apps/web/src/core/data/providers/mock_provider.ts
+++ b/apps/web/src/core/data/providers/mock_provider.ts
@@ -21,6 +21,14 @@ export function createLocalMockDataSources(options: MockProviderOptions): AppDat
   const basePath = (options.basePath ?? 'apps/web/src/core/data/mock/local').replace(/\/+$/, '');
   const loader = options.loader;
 
+  let profileCache: ApiProfileContextGetEnvelope | null = null;
+
+  async function loadProfile(): Promise<ApiProfileContextGetEnvelope> {
+    if (profileCache) return profileCache;
+    profileCache = await loader.load<ApiProfileContextGetEnvelope>(`${basePath}/profile_context.json`);
+    return profileCache;
+  }
+
   return {
     dashboard: {
       async getDashboardHome(): Promise<ApiDashboardHomeEnvelope> {
@@ -58,14 +66,40 @@ export function createLocalMockDataSources(options: MockProviderOptions): AppDat
     },
     profile: {
       async getProfileContext(): Promise<ApiProfileContextGetEnvelope> {
-        return await loader.load<ApiProfileContextGetEnvelope>(`${basePath}/profile_context.json`);
+        return await loadProfile();
       },
       async putProfileContext(_input: ProfileContextPutRequest): Promise<ApiProfileContextPutEnvelope> {
-        // Mock simples: reusa o GET como estado "persistido".
-        const current = await loader.load<ApiProfileContextGetEnvelope>(`${basePath}/profile_context.json`);
+        // Mock persistente em memoria: aplica patch e devolve estado atualizado
+        const input = _input;
+        const current = await loadProfile();
         if (!current.ok) return current as unknown as ApiProfileContextPutEnvelope;
 
-        const { backendHealth, ...rest } = current.data;
+        const nextContext = { ...current.data.context, ...(input.context ?? {}) };
+        const currentOnboarding = current.data.onboarding;
+
+        const step = input.step ?? null;
+        const completedSteps = new Set(currentOnboarding.completedSteps ?? []);
+        if (step) completedSteps.add(step);
+
+        const nextOnboarding = {
+          ...currentOnboarding,
+          currentStep: step ?? currentOnboarding.currentStep,
+          completedSteps: Array.from(completedSteps),
+          completed: step === 'confirm' ? true : currentOnboarding.completed,
+          completedAt: step === 'confirm' ? new Date().toISOString() : currentOnboarding.completedAt,
+          homeUnlocked: step === 'confirm' ? true : currentOnboarding.homeUnlocked
+        };
+
+        profileCache = {
+          ...current,
+          data: {
+            ...current.data,
+            context: nextContext,
+            onboarding: nextOnboarding
+          }
+        };
+
+        const { backendHealth, ...rest } = profileCache.data;
         return {
           ok: true,
           meta: current.meta,

--- a/apps/web/src/features/home/HomeScreen.tsx
+++ b/apps/web/src/features/home/HomeScreen.tsx
@@ -1,0 +1,151 @@
+import React, { useEffect, useState } from 'react';
+import type { AppDataSources } from '../../core/data/data_sources';
+import type { DashboardHomeData } from '../../core/data/contracts';
+
+export interface HomeScreenProps {
+  dataSources: AppDataSources;
+  onGoToOnboarding(): void;
+  onGoToPortfolio(): void;
+}
+
+export function HomeScreen(props: HomeScreenProps): JSX.Element {
+  const [state, setState] = useState<
+    | { kind: 'loading' }
+    | { kind: 'error'; message: string }
+    | { kind: 'ready'; data: DashboardHomeData }
+  >({ kind: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await props.dataSources.dashboard.getDashboardHome();
+        if (cancelled) return;
+        if (!res.ok) {
+          setState({ kind: 'error', message: `${res.error.code}: ${res.error.message}` });
+          return;
+        }
+        setState({ kind: 'ready', data: res.data });
+      } catch (e) {
+        if (cancelled) return;
+        setState({ kind: 'error', message: e instanceof Error ? e.message : 'Falha ao carregar' });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [props.dataSources]);
+
+  return (
+    <div className="app">
+      <div className="container" style={{ paddingTop: 18, paddingBottom: 28 }}>
+        <header style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <img
+              src="/brand/esquilo-icon.png"
+              alt="Esquilo"
+              width={34}
+              height={34}
+              style={{ borderRadius: 12, background: 'rgba(255,255,255,0.85)', boxShadow: 'var(--shadow-1)' }}
+            />
+            <div style={{ fontWeight: 900 }}>Home</div>
+          </div>
+          <button className="btn btnGhost" onClick={props.onGoToOnboarding}>
+            Editar contexto
+          </button>
+        </header>
+
+        <main style={{ marginTop: 14 }}>
+          {state.kind === 'loading' ? (
+            <div className="card" style={{ padding: 16 }}>
+              Carregando...
+            </div>
+          ) : state.kind === 'error' ? (
+            <div className="card" style={{ padding: 16 }}>
+              <div style={{ fontWeight: 900, marginBottom: 6 }}>Nao foi possivel carregar</div>
+              <div style={{ color: 'var(--c-slate)' }}>{state.message}</div>
+            </div>
+          ) : (
+            <HomeContent data={state.data} onGoToPortfolio={props.onGoToPortfolio} />
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}
+
+function HomeContent(props: { data: DashboardHomeData; onGoToPortfolio(): void }): JSX.Element {
+  const d = props.data;
+
+  if (d.screenState === 'redirect_onboarding') {
+    return (
+      <div className="card" style={{ padding: 16 }}>
+        <div style={{ fontWeight: 900, marginBottom: 6 }}>Antes de tudo</div>
+        <div style={{ color: 'var(--c-slate)' }}>Vamos completar seu contexto para personalizar a leitura.</div>
+      </div>
+    );
+  }
+
+  if (d.screenState === 'empty') {
+    return (
+      <div className="card" style={{ padding: 16 }}>
+        <div style={{ fontWeight: 900, marginBottom: 6 }}>{d.emptyState.title}</div>
+        <div style={{ color: 'var(--c-slate)' }}>{d.emptyState.body}</div>
+        <div style={{ marginTop: 12 }}>
+          <button className="btn btnPrimary" onClick={props.onGoToPortfolio}>
+            {d.emptyState.ctaLabel}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ready / portfolio_ready_analysis_pending: para US002 o valor é o herói + problema + ação.
+  return (
+    <div style={{ display: 'grid', gap: 12 }}>
+      <div className="card" style={{ padding: 16 }}>
+        <div style={{ fontWeight: 900, marginBottom: 10 }}>Resumo</div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))', gap: 10 }}>
+          <Kpi label="Patrimonio" value={formatMoney(d.hero.totalEquity)} />
+          <Kpi label="Score" value={String(d.score.value)} />
+          <Kpi label="Disponivel" value={formatMoney(d.hero.totalEquity * 0.02)} />
+        </div>
+      </div>
+
+      <div className="card" style={{ padding: 16 }}>
+        <div style={{ fontWeight: 900, marginBottom: 6 }}>Problema principal</div>
+        <div style={{ fontFamily: 'var(--font-serif)', fontSize: 18, letterSpacing: -0.2 }}>{d.primaryProblem.title}</div>
+        <div style={{ marginTop: 6, color: 'var(--c-slate)', lineHeight: 1.5 }}>{d.primaryProblem.body}</div>
+      </div>
+
+      <div className="card" style={{ padding: 16, borderColor: 'rgba(245,106,42,0.35)' }}>
+        <div style={{ fontWeight: 900, marginBottom: 6 }}>Acao recomendada</div>
+        <div style={{ fontFamily: 'var(--font-serif)', fontSize: 18, letterSpacing: -0.2 }}>{d.primaryAction.title}</div>
+        <div style={{ marginTop: 6, color: 'var(--c-slate)', lineHeight: 1.5 }}>{d.primaryAction.body}</div>
+        <div style={{ marginTop: 12 }}>
+          <button className="btn btnPrimary" onClick={props.onGoToPortfolio}>
+            {d.primaryAction.ctaLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Kpi(props: { label: string; value: string }): JSX.Element {
+  return (
+    <div style={{ padding: 12, borderRadius: 14, border: '1px solid rgba(11,18,24,0.10)', background: 'rgba(255,255,255,0.7)' }}>
+      <div style={{ fontSize: 12, color: 'var(--c-slate)', marginBottom: 6 }}>{props.label}</div>
+      <div style={{ fontWeight: 900, fontSize: 18, letterSpacing: -0.2 }}>{props.value}</div>
+    </div>
+  );
+}
+
+function formatMoney(v: number): string {
+  try {
+    return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(v);
+  } catch {
+    return `R$ ${v.toFixed(2)}`;
+  }
+}
+

--- a/apps/web/src/features/onboarding/OnboardingScreen.tsx
+++ b/apps/web/src/features/onboarding/OnboardingScreen.tsx
@@ -1,0 +1,401 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import type { AppDataSources } from '../../core/data/data_sources';
+import type {
+  ProfileContextPayload,
+  ProfileContextPutRequest,
+  ProfilePlatformsUsed
+} from '../../core/data/contracts';
+
+type StepId = 'goal' | 'income_horizon' | 'risk_quiz' | 'platforms' | 'confirm';
+
+const STEPS: Array<{ id: StepId; title: string; hint: string }> = [
+  { id: 'goal', title: 'Seu objetivo', hint: 'Uma escolha simples para calibrar a leitura.' },
+  { id: 'income_horizon', title: 'Renda e horizonte', hint: 'Só o suficiente para evitar recomendação errada.' },
+  { id: 'risk_quiz', title: 'Risco', hint: 'Sem quiz pesado agora. Só um norte.' },
+  { id: 'platforms', title: 'Plataformas', hint: 'Para sugerir o melhor caminho de importação.' },
+  { id: 'confirm', title: 'Revisao', hint: 'Confirme o contexto antes de seguir.' }
+];
+
+export interface OnboardingScreenProps {
+  dataSources: AppDataSources;
+  onDone(): void;
+  onSkip(): void;
+}
+
+export function OnboardingScreen(props: OnboardingScreenProps): JSX.Element {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [stepIndex, setStepIndex] = useState(0);
+
+  const [context, setContext] = useState<ProfileContextPayload>({
+    financialGoal: null,
+    monthlyIncomeRange: null,
+    monthlyInvestmentTarget: null,
+    availableToInvest: null,
+    riskProfileSelfDeclared: null,
+    riskProfileQuizResult: null,
+    riskProfileEffective: null,
+    investmentHorizon: null,
+    platformsUsed: null,
+    displayPreferences: null
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await props.dataSources.profile.getProfileContext();
+        if (cancelled) return;
+        if (!res.ok) {
+          setError(`${res.error.code}: ${res.error.message}`);
+          setLoading(false);
+          return;
+        }
+        setContext(res.data.context ?? context);
+        setLoading(false);
+      } catch (e) {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : 'Falha ao carregar contexto');
+        setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.dataSources]);
+
+  const current = STEPS[stepIndex];
+  const progress = useMemo(() => Math.round(((stepIndex + 1) / STEPS.length) * 100), [stepIndex]);
+
+  async function saveStep(step: StepId, patch: Partial<ProfileContextPayload>): Promise<boolean> {
+    setError(null);
+    const input: ProfileContextPutRequest = { step, context: patch };
+    try {
+      const res = await props.dataSources.profile.putProfileContext(input);
+      if (!res.ok) {
+        setError(`${res.error.code}: ${res.error.message}`);
+        return false;
+      }
+      // backend pode devolver contexto normalizado; respeita isso
+      setContext((c) => ({ ...c, ...patch, ...res.data.context }));
+      return true;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Falha ao salvar');
+      return false;
+    }
+  }
+
+  async function next(): Promise<void> {
+    if (!current) return;
+
+    // salva no fim de cada passo para manter UX leve e evitar roundtrip por clique.
+    if (current.id === 'goal') {
+      const ok = await saveStep('goal', { financialGoal: context.financialGoal });
+      if (!ok) return;
+    }
+    if (current.id === 'income_horizon') {
+      const ok = await saveStep('income_horizon', {
+        monthlyIncomeRange: context.monthlyIncomeRange,
+        monthlyInvestmentTarget: context.monthlyInvestmentTarget,
+        availableToInvest: context.availableToInvest,
+        investmentHorizon: context.investmentHorizon
+      });
+      if (!ok) return;
+    }
+    if (current.id === 'risk_quiz') {
+      const ok = await saveStep('risk_quiz', { riskProfileSelfDeclared: context.riskProfileSelfDeclared });
+      if (!ok) return;
+    }
+    if (current.id === 'platforms') {
+      const ok = await saveStep('platforms', { platformsUsed: context.platformsUsed });
+      if (!ok) return;
+    }
+    if (current.id === 'confirm') {
+      const ok = await saveStep('confirm', {});
+      if (!ok) return;
+      props.onDone();
+      return;
+    }
+
+    setStepIndex((i) => Math.min(i + 1, STEPS.length - 1));
+  }
+
+  function back(): void {
+    setError(null);
+    setStepIndex((i) => Math.max(i - 1, 0));
+  }
+
+  return (
+    <div className="app">
+      <div className="container" style={{ paddingTop: 18, paddingBottom: 28 }}>
+        <header style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <img
+              src="/brand/esquilo-icon.png"
+              alt="Esquilo"
+              width={34}
+              height={34}
+              style={{ borderRadius: 12, background: 'rgba(255,255,255,0.85)', boxShadow: 'var(--shadow-1)' }}
+            />
+            <div>
+              <div style={{ fontWeight: 900 }}>Onboarding</div>
+              <div style={{ fontSize: 12, opacity: 0.75 }}>{progress}%</div>
+            </div>
+          </div>
+          <button className="btn btnGhost" onClick={props.onSkip}>
+            Ver exemplo primeiro
+          </button>
+        </header>
+
+        <main style={{ marginTop: 14 }}>
+          {loading ? (
+            <div className="card" style={{ padding: 16 }}>
+              Carregando...
+            </div>
+          ) : (
+            <div className="card" style={{ padding: 16 }}>
+              <div className="pill">
+                <span className="pillDot" />
+                <span style={{ fontSize: 12, fontWeight: 700 }}>{current.title}</span>
+              </div>
+              <div style={{ marginTop: 10, color: 'var(--c-slate)' }}>{current.hint}</div>
+
+              {error ? (
+                <div style={{ marginTop: 10, padding: 10, borderRadius: 12, background: 'rgba(232,92,92,0.10)', border: '1px solid rgba(232,92,92,0.25)' }}>
+                  <div style={{ fontWeight: 900, marginBottom: 4 }}>Nao foi possivel salvar</div>
+                  <div style={{ color: 'var(--c-slate)' }}>{error}</div>
+                </div>
+              ) : null}
+
+              <div style={{ marginTop: 14 }}>
+                {current.id === 'goal' ? (
+                  <GoalStep value={context.financialGoal} onChange={(v) => setContext((c) => ({ ...c, financialGoal: v }))} />
+                ) : null}
+                {current.id === 'income_horizon' ? (
+                  <IncomeHorizonStep
+                    value={context}
+                    onChange={(patch) => setContext((c) => ({ ...c, ...patch }))}
+                  />
+                ) : null}
+                {current.id === 'risk_quiz' ? (
+                  <RiskStep value={context.riskProfileSelfDeclared} onChange={(v) => setContext((c) => ({ ...c, riskProfileSelfDeclared: v }))} />
+                ) : null}
+                {current.id === 'platforms' ? (
+                  <PlatformsStep
+                    value={context.platformsUsed}
+                    onChange={(v) => setContext((c) => ({ ...c, platformsUsed: v }))}
+                  />
+                ) : null}
+                {current.id === 'confirm' ? <ConfirmStep context={context} /> : null}
+              </div>
+
+              <div style={{ marginTop: 16, display: 'flex', gap: 10, flexWrap: 'wrap', justifyContent: 'space-between' }}>
+                <div style={{ display: 'flex', gap: 10 }}>
+                  <button className="btn btnGhost" onClick={back} disabled={stepIndex === 0}>
+                    Voltar
+                  </button>
+                </div>
+                <div style={{ display: 'flex', gap: 10 }}>
+                  <button className="btn btnPrimary" onClick={() => void next()}>
+                    {current.id === 'confirm' ? 'Concluir' : 'Continuar'}
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}
+
+function ChoiceRow(props: { label: string; hint?: string; selected: boolean; onClick(): void }): JSX.Element {
+  return (
+    <button
+      type="button"
+      className="btn btnGhost"
+      onClick={props.onClick}
+      style={{
+        width: '100%',
+        textAlign: 'left',
+        padding: '12px 14px',
+        borderRadius: 14,
+        borderColor: props.selected ? 'rgba(245,106,42,0.55)' : 'rgba(11,18,24,0.14)',
+        background: props.selected ? 'rgba(245,106,42,0.10)' : 'rgba(255,255,255,0.72)'
+      }}
+    >
+      <div style={{ fontWeight: 900 }}>{props.label}</div>
+      {props.hint ? <div style={{ fontSize: 12, color: 'var(--c-slate)', marginTop: 4 }}>{props.hint}</div> : null}
+    </button>
+  );
+}
+
+function GoalStep(props: { value: string | null; onChange(v: string): void }): JSX.Element {
+  const options = [
+    { v: 'crescer patrimonio', label: 'Crescer patrimonio', hint: 'Aumentar capital com consistencia.' },
+    { v: 'equilibrar e crescer', label: 'Equilibrar e crescer', hint: 'Crescer sem aumentar risco demais.' },
+    { v: 'proteger patrimonio', label: 'Proteger patrimonio', hint: 'Reduzir volatilidade e riscos.' }
+  ];
+  return (
+    <div style={{ display: 'grid', gap: 10 }}>
+      {options.map((o) => (
+        <ChoiceRow key={o.v} label={o.label} hint={o.hint} selected={props.value === o.v} onClick={() => props.onChange(o.v)} />
+      ))}
+    </div>
+  );
+}
+
+function IncomeHorizonStep(props: { value: ProfileContextPayload; onChange(patch: Partial<ProfileContextPayload>): void }): JSX.Element {
+  return (
+    <div style={{ display: 'grid', gap: 12 }}>
+      <div>
+        <div style={{ fontWeight: 900, marginBottom: 6 }}>Faixa de renda</div>
+        <div style={{ display: 'grid', gap: 10 }}>
+          {['ate_5k', '5k-10k', '10k-15k', '15k+'].map((v) => (
+            <ChoiceRow
+              key={v}
+              label={v.replace('_', ' ')}
+              selected={props.value.monthlyIncomeRange === v}
+              onClick={() => props.onChange({ monthlyIncomeRange: v })}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: 10 }}>
+        <NumberField
+          label="Aporte mensal (meta)"
+          value={props.value.monthlyInvestmentTarget}
+          onChange={(n) => props.onChange({ monthlyInvestmentTarget: n })}
+        />
+        <NumberField
+          label="Disponivel agora"
+          value={props.value.availableToInvest}
+          onChange={(n) => props.onChange({ availableToInvest: n })}
+        />
+      </div>
+
+      <div>
+        <div style={{ fontWeight: 900, marginBottom: 6 }}>Horizonte</div>
+        <div style={{ display: 'grid', gap: 10 }}>
+          {[
+            { v: 'curto_prazo', label: 'Curto prazo', hint: '0 a 2 anos' },
+            { v: 'medio_prazo', label: 'Medio prazo', hint: '2 a 5 anos' },
+            { v: 'longo_prazo', label: 'Longo prazo', hint: '5+ anos' }
+          ].map((o) => (
+            <ChoiceRow
+              key={o.v}
+              label={o.label}
+              hint={o.hint}
+              selected={props.value.investmentHorizon === o.v}
+              onClick={() => props.onChange({ investmentHorizon: o.v })}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function RiskStep(props: { value: string | null; onChange(v: string): void }): JSX.Element {
+  const options = [
+    { v: 'conservador', label: 'Conservador', hint: 'Prioriza estabilidade.' },
+    { v: 'moderado', label: 'Moderado', hint: 'Equilibrio entre risco e retorno.' },
+    { v: 'arrojado', label: 'Arrojado', hint: 'Aceita volatilidade para buscar retorno.' }
+  ];
+  return (
+    <div style={{ display: 'grid', gap: 10 }}>
+      {options.map((o) => (
+        <ChoiceRow key={o.v} label={o.label} hint={o.hint} selected={props.value === o.v} onClick={() => props.onChange(o.v)} />
+      ))}
+    </div>
+  );
+}
+
+function PlatformsStep(props: { value: ProfilePlatformsUsed | null; onChange(v: ProfilePlatformsUsed): void }): JSX.Element {
+  const current = props.value ?? { platformIds: [], otherPlatforms: [] };
+  function toggle(id: string) {
+    const set = new Set(current.platformIds);
+    if (set.has(id)) set.delete(id);
+    else set.add(id);
+    props.onChange({ ...current, platformIds: Array.from(set) });
+  }
+  const items = [
+    { id: 'xp', label: 'XP' },
+    { id: 'ion', label: 'Ion' },
+    { id: 'btg', label: 'BTG' },
+    { id: 'nubank', label: 'Nu / Nubank' }
+  ];
+
+  return (
+    <div style={{ display: 'grid', gap: 10 }}>
+      {items.map((it) => (
+        <ChoiceRow
+          key={it.id}
+          label={it.label}
+          selected={current.platformIds.includes(it.id)}
+          onClick={() => toggle(it.id)}
+        />
+      ))}
+      <div style={{ marginTop: 4, fontSize: 12, color: 'var(--c-slate)' }}>
+        Dica: isso ajuda o produto a sugerir o caminho mais simples de importacao.
+      </div>
+    </div>
+  );
+}
+
+function ConfirmStep(props: { context: ProfileContextPayload }): JSX.Element {
+  const c = props.context;
+  return (
+    <div className="card" style={{ padding: 14, background: 'rgba(245,240,235,0.65)', borderColor: 'rgba(11,18,24,0.08)' }}>
+      <div style={{ fontWeight: 900, marginBottom: 10 }}>Resumo</div>
+      <div style={{ display: 'grid', gap: 6, color: 'var(--c-slate)', lineHeight: 1.55 }}>
+        <Row k="Objetivo" v={c.financialGoal ?? 'nao informado'} />
+        <Row k="Renda" v={c.monthlyIncomeRange ?? 'nao informado'} />
+        <Row k="Horizonte" v={c.investmentHorizon ?? 'nao informado'} />
+        <Row k="Risco" v={c.riskProfileSelfDeclared ?? 'nao informado'} />
+        <Row k="Plataformas" v={(c.platformsUsed?.platformIds ?? []).join(', ') || 'nao informado'} />
+      </div>
+    </div>
+  );
+}
+
+function Row(props: { k: string; v: string }): JSX.Element {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12 }}>
+      <span style={{ fontWeight: 800 }}>{props.k}</span>
+      <span>{props.v}</span>
+    </div>
+  );
+}
+
+function NumberField(props: { label: string; value: number | null; onChange(v: number | null): void }): JSX.Element {
+  return (
+    <label style={{ display: 'grid', gap: 6 }}>
+      <span style={{ fontSize: 12, color: 'var(--c-slate)', fontWeight: 800 }}>{props.label}</span>
+      <input
+        value={props.value ?? ''}
+        onChange={(e) => {
+          const raw = e.target.value.trim();
+          if (!raw) {
+            props.onChange(null);
+            return;
+          }
+          const n = Number(raw.replace(',', '.'));
+          props.onChange(Number.isFinite(n) ? n : null);
+        }}
+        inputMode="decimal"
+        placeholder="0"
+        style={{
+          padding: '12px 12px',
+          borderRadius: 14,
+          border: '1px solid rgba(11,18,24,0.14)',
+          background: 'rgba(255,255,255,0.72)',
+          font: 'inherit'
+        }}
+      />
+    </label>
+  );
+}
+


### PR DESCRIPTION
Atende #13 (US002).\n\nO que entra:\n- Onboarding por passos curtos (leve, sem cara de formulario bancario)\n- Opcao de pular para ver valor primeiro\n- Home preview consumindo mock de /v1/dashboard/home (resumo + problema principal + acao)\n- Mock provider de profile com persistencia em memoria para testar fluxo sem backend\n\nArquitetura: UI consome AppShell + DataSourceFactory (sem fetch espalhado).