### PR TITLE
Web: navegacao pela Home (shell nav)

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -80,6 +80,7 @@ export function App(): JSX.Element {
         dataSources={dataSources}
         onGoToOnboarding={() => navigate('/onboarding')}
         onGoToPortfolio={() => navigate('/portfolio')}
+        onGoToRadar={() => navigate('/radar')}
       />
     );
   }
@@ -90,6 +91,8 @@ export function App(): JSX.Element {
         dataSources={dataSources}
         onBack={() => navigate('/home')}
         onOpenHolding={({ portfolioId, holdingId }) => navigate(`/portfolio/${encodeURIComponent(portfolioId)}/holdings/${encodeURIComponent(holdingId)}`)}
+        onGoToHome={() => navigate('/home')}
+        onGoToRadar={() => navigate('/radar')}
       />
     );
   }
@@ -111,6 +114,8 @@ export function App(): JSX.Element {
         dataSources={dataSources}
         onBack={() => navigate('/home')}
         onGoToTarget={(path) => navigate(path)}
+        onGoToHome={() => navigate('/home')}
+        onGoToPortfolio={() => navigate('/portfolio')}
       />
     );
   }

--- a/apps/web/src/app/ShellLayout.tsx
+++ b/apps/web/src/app/ShellLayout.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import type { RouteId } from '../core/router/routes';
+
+export type NavItem = { id: RouteId; label: string; href: string };
+
+const NAV: NavItem[] = [
+  { id: 'home', label: 'Home', href: '/home' },
+  { id: 'portfolio', label: 'Carteira', href: '/portfolio' },
+  { id: 'radar', label: 'Radar', href: '/radar' },
+  { id: 'history', label: 'Historico', href: '/history' },
+  { id: 'profile', label: 'Perfil', href: '/profile' },
+  { id: 'imports', label: 'Importacoes', href: '/imports' }
+];
+
+export interface ShellLayoutProps {
+  title: string;
+  activeRouteId: RouteId;
+  onNavigate(href: string): void;
+  rightSlot?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export function ShellLayout(props: ShellLayoutProps): JSX.Element {
+  return (
+    <div className="app">
+      <div className="container" style={{ paddingTop: 18, paddingBottom: 28 }}>
+        <header className="shellHeader">
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <img
+              src="/brand/esquilo-icon.png"
+              alt="Esquilo"
+              width={34}
+              height={34}
+              style={{ borderRadius: 12, background: 'rgba(255,255,255,0.85)', boxShadow: 'var(--shadow-1)' }}
+            />
+            <div>
+              <div style={{ fontWeight: 900 }}>{props.title}</div>
+              <div style={{ fontSize: 12, opacity: 0.75 }}>Consolidar. Traduzir. Orientar.</div>
+            </div>
+          </div>
+
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            {props.rightSlot ?? null}
+          </div>
+        </header>
+
+        <nav className="shellNav" aria-label="Navegacao principal">
+          {NAV.map((it) => (
+            <button
+              key={it.id}
+              type="button"
+              className={`shellNavItem ${props.activeRouteId === it.id ? 'shellNavItemActive' : ''}`}
+              aria-current={props.activeRouteId === it.id ? 'page' : undefined}
+              onClick={() => props.onNavigate(it.href)}
+            >
+              {it.label}
+            </button>
+          ))}
+        </nav>
+
+        <main style={{ marginTop: 14 }}>{props.children}</main>
+      </div>
+    </div>
+  );
+}
+

--- a/apps/web/src/features/home/HomeScreen.tsx
+++ b/apps/web/src/features/home/HomeScreen.tsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import type { AppDataSources } from '../../core/data/data_sources';
 import type { DashboardHomeData } from '../../core/data/contracts';
+import { ShellLayout } from '../../app/ShellLayout';
 
 export interface HomeScreenProps {
   dataSources: AppDataSources;
   onGoToOnboarding(): void;
   onGoToPortfolio(): void;
+  onGoToRadar(): void;
 }
 
 export function HomeScreen(props: HomeScreenProps): JSX.Element {
@@ -37,26 +39,21 @@ export function HomeScreen(props: HomeScreenProps): JSX.Element {
   }, [props.dataSources]);
 
   return (
-    <div className="app">
-      <div className="container" style={{ paddingTop: 18, paddingBottom: 28 }}>
-        <header style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-            <img
-              src="/brand/esquilo-icon.png"
-              alt="Esquilo"
-              width={34}
-              height={34}
-              style={{ borderRadius: 12, background: 'rgba(255,255,255,0.85)', boxShadow: 'var(--shadow-1)' }}
-            />
-            <div style={{ fontWeight: 900 }}>Home</div>
-          </div>
-          <button className="btn btnGhost" onClick={props.onGoToOnboarding}>
-            Editar contexto
-          </button>
-        </header>
-
-        <main style={{ marginTop: 14 }}>
-          {state.kind === 'loading' ? (
+    <ShellLayout
+      title="Home"
+      activeRouteId="home"
+      onNavigate={(href) => {
+        if (href === '/portfolio') props.onGoToPortfolio();
+        else if (href === '/radar') props.onGoToRadar();
+        else if (href === '/profile') props.onGoToOnboarding();
+      }}
+      rightSlot={
+        <button className="btn btnGhost" onClick={props.onGoToOnboarding}>
+          Editar contexto
+        </button>
+      }
+    >
+      {state.kind === 'loading' ? (
             <div className="card" style={{ padding: 16 }}>
               Carregando...
             </div>
@@ -66,15 +63,13 @@ export function HomeScreen(props: HomeScreenProps): JSX.Element {
               <div style={{ color: 'var(--c-slate)' }}>{state.message}</div>
             </div>
           ) : (
-            <HomeContent data={state.data} onGoToPortfolio={props.onGoToPortfolio} />
+            <HomeContent data={state.data} onGoToPortfolio={props.onGoToPortfolio} onGoToRadar={props.onGoToRadar} />
           )}
-        </main>
-      </div>
-    </div>
+    </ShellLayout>
   );
 }
 
-function HomeContent(props: { data: DashboardHomeData; onGoToPortfolio(): void }): JSX.Element {
+function HomeContent(props: { data: DashboardHomeData; onGoToPortfolio(): void; onGoToRadar(): void }): JSX.Element {
   const d = props.data;
 
   if (d.screenState === 'redirect_onboarding') {
@@ -109,6 +104,11 @@ function HomeContent(props: { data: DashboardHomeData; onGoToPortfolio(): void }
           <Kpi label="Patrimonio" value={formatMoney(d.hero.totalEquity)} />
           <Kpi label="Score" value={String(d.score.value)} />
           <Kpi label="Disponivel" value={formatMoney(d.hero.totalEquity * 0.02)} />
+        </div>
+        <div style={{ marginTop: 12 }}>
+          <button className="btn btnGhost" onClick={props.onGoToRadar}>
+            Abrir score
+          </button>
         </div>
       </div>
 
@@ -148,4 +148,3 @@ function formatMoney(v: number): string {
     return `R$ ${v.toFixed(2)}`;
   }
 }
-

--- a/apps/web/src/features/portfolio/PortfolioScreen.tsx
+++ b/apps/web/src/features/portfolio/PortfolioScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import type { AppDataSources } from '../../core/data/data_sources';
 import type { PortfolioData, PortfolioGroup, PortfolioHolding } from '../../core/data/contracts';
+import { ShellLayout } from '../../app/ShellLayout';
 
 type PerfFilter = 'all' | 'best' | 'worst';
 
@@ -8,6 +9,8 @@ export interface PortfolioScreenProps {
   dataSources: AppDataSources;
   onBack(): void;
   onOpenHolding(input: { portfolioId: string; holdingId: string }): void;
+  onGoToHome(): void;
+  onGoToRadar(): void;
 }
 
 export function PortfolioScreen(props: PortfolioScreenProps): JSX.Element {
@@ -58,26 +61,21 @@ export function PortfolioScreen(props: PortfolioScreenProps): JSX.Element {
   }, [state, query]);
 
   return (
-    <div className="app">
-      <div className="container" style={{ paddingTop: 18, paddingBottom: 28 }}>
-        <header style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-            <img
-              src="/brand/esquilo-icon.png"
-              alt="Esquilo"
-              width={34}
-              height={34}
-              style={{ borderRadius: 12, background: 'rgba(255,255,255,0.85)', boxShadow: 'var(--shadow-1)' }}
-            />
-            <div style={{ fontWeight: 900 }}>Carteira</div>
-          </div>
-          <button className="btn btnGhost" onClick={props.onBack}>
-            Voltar
-          </button>
-        </header>
-
-        <main style={{ marginTop: 14, display: 'grid', gap: 12 }}>
-          <div className="card" style={{ padding: 14 }}>
+    <ShellLayout
+      title="Carteira"
+      activeRouteId="portfolio"
+      onNavigate={(href) => {
+        if (href === '/home') props.onGoToHome();
+        else if (href === '/radar') props.onGoToRadar();
+      }}
+      rightSlot={
+        <button className="btn btnGhost" onClick={props.onBack}>
+          Voltar
+        </button>
+      }
+    >
+      <div style={{ display: 'grid', gap: 12 }}>
+        <div className="card" style={{ padding: 14 }}>
             <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', alignItems: 'center', justifyContent: 'space-between' }}>
               <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
                 <FilterPill label="Todos" selected={perf === 'all'} onClick={() => setPerf('all')} />
@@ -100,7 +98,7 @@ export function PortfolioScreen(props: PortfolioScreenProps): JSX.Element {
             </div>
           </div>
 
-          {state.kind === 'loading' ? (
+        {state.kind === 'loading' ? (
             <div className="card" style={{ padding: 16 }}>
               Carregando...
             </div>
@@ -112,9 +110,8 @@ export function PortfolioScreen(props: PortfolioScreenProps): JSX.Element {
           ) : (
             <PortfolioContent data={filtered ?? state.data} onOpenHolding={props.onOpenHolding} />
           )}
-        </main>
       </div>
-    </div>
+    </ShellLayout>
   );
 }
 
@@ -274,4 +271,3 @@ function formatPct(v: number): string {
   const s = (n >= 0 ? `+${n}` : String(n)).replace('.', ',');
   return `${s}%`;
 }
-

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -80,3 +80,37 @@
     grid-template-columns: 1fr;
   }
 }
+
+.shellHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.shellNav {
+  margin-top: 12px;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.shellNavItem {
+  appearance: none;
+  border: 1px solid rgba(11, 18, 24, 0.14);
+  background: rgba(255, 255, 255, 0.72);
+  border-radius: 999px;
+  padding: 8px 12px;
+  font: inherit;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.shellNavItem:hover {
+  filter: brightness(1.02);
+}
+
+.shellNavItemActive {
+  border-color: rgba(11, 18, 24, 0.28);
+  background: rgba(11, 18, 24, 0.06);
+}


### PR DESCRIPTION
Atende #38 (US027).\n\nO que entra:\n- ShellLayout reutilizavel (header + nav) alinhado ao BrandBook\n- Aplicado em Home/Carteira/Radar para saltos rapidos entre areas\n- Home ganha atalho explicito para score (Radar) sem virar painel baguncado\n\nObs: Historico/Perfil/Importacoes ficam preparados (rotas ja existem), mas ainda sem UI.