### PR TITLE
Web: central de importacoes (historico)

### DIFF
--- a/apps/web/app/src/core/data/mock/hml/imports_center.json
+++ b/apps/web/app/src/core/data/mock/hml/imports_center.json
@@ -1,0 +1,51 @@
+{
+  "ok": true,
+  "meta": {
+    "requestId": "req_local_imports_center",
+    "timestamp": "2026-03-31T01:00:00Z",
+    "version": "v1"
+  },
+  "data": {
+    "screenState": "ready",
+    "portfolioId": "pfl_seed_balanced",
+    "summary": {
+      "totalImports": 2,
+      "pendingImports": 1,
+      "completedImports": 1,
+      "failedImports": 0
+    },
+    "imports": [
+      {
+        "id": "imp_bal_2",
+        "origin": "B3_CSV",
+        "originLabel": "CSV da B3",
+        "status": "PREVIEW_READY",
+        "statusLabel": "Pronta para commit",
+        "fileName": "b3.csv",
+        "mimeType": "text/csv",
+        "totals": { "totalRows": 18, "validRows": 16, "invalidRows": 1, "duplicateRows": 1 },
+        "createdAt": "2026-03-31T01:00:00Z",
+        "updatedAt": "2026-03-31T01:05:00Z",
+        "snapshot": null,
+        "primaryAction": { "code": "resume_import", "title": "Retomar revisão", "target": "/imports/imp_bal_2/preview" },
+        "secondaryAction": null
+      },
+      {
+        "id": "imp_bal_1",
+        "origin": "CUSTOM_TEMPLATE",
+        "originLabel": "Template próprio",
+        "status": "COMMITTED",
+        "statusLabel": "Concluída",
+        "fileName": "template.xlsx",
+        "mimeType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "totals": { "totalRows": 12, "validRows": 12, "invalidRows": 0, "duplicateRows": 0 },
+        "createdAt": "2026-03-01T00:00:00.000Z",
+        "updatedAt": "2026-03-01T00:02:00.000Z",
+        "snapshot": { "id": "snp_bal_0", "referenceDate": "2026-02-28", "target": "/history/snapshots" },
+        "primaryAction": { "code": "open_preview", "title": "Ver importação", "target": "/imports/imp_bal_1/preview" },
+        "secondaryAction": { "code": "open_snapshot", "title": "Ver snapshot", "target": "/history/snapshots" }
+      }
+    ]
+  }
+}
+

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -10,6 +10,7 @@ import { PortfolioScreen } from '../features/portfolio/PortfolioScreen';
 import { HoldingDetailScreen } from '../features/holding_detail/HoldingDetailScreen';
 import { RadarScreen } from '../features/radar/RadarScreen';
 import { HistoryScreen } from '../features/history/HistoryScreen';
+import { ImportsCenterScreen } from '../features/imports/ImportsCenterScreen';
 
 function getEnv(): AppEnv {
   const raw = String(import.meta.env.VITE_APP_ENV ?? 'local');
@@ -123,6 +124,10 @@ export function App(): JSX.Element {
 
   if (state.route.id === 'history') {
     return <HistoryScreen dataSources={dataSources} onGoToTarget={(path) => navigate(path)} />;
+  }
+
+  if (state.route.id === 'imports') {
+    return <ImportsCenterScreen dataSources={dataSources} onGoToTarget={(path) => navigate(path)} />;
   }
 
   // placeholder headless: as telas vão entrando uma a uma, sempre com contratos/mocks.

--- a/apps/web/src/core/data/contracts.ts
+++ b/apps/web/src/core/data/contracts.ts
@@ -283,6 +283,61 @@ export type HoldingDetailDataReady = {
 export type HoldingDetailData = ScreenStateRedirect | HoldingDetailDataReady;
 export type ApiHoldingDetailEnvelope = ApiEnvelope<HoldingDetailData>;
 
+// ===== Imports center (history/imports) =====
+
+export type ImportsCenterImportTotals = {
+  totalRows: number;
+  validRows: number;
+  invalidRows: number;
+  duplicateRows: number;
+};
+
+export type ImportsCenterImportSnapshot = {
+  id: string;
+  referenceDate: string | null;
+  target: string;
+};
+
+export type ImportsCenterImportAction = {
+  code: string;
+  title: string;
+  target: string;
+};
+
+export type ImportsCenterImportItem = {
+  id: string;
+  origin: string;
+  originLabel: string;
+  status: string;
+  statusLabel: string;
+  fileName: string | null;
+  mimeType: string | null;
+  totals: ImportsCenterImportTotals;
+  createdAt: string;
+  updatedAt: string;
+  snapshot: ImportsCenterImportSnapshot | null;
+  primaryAction: ImportsCenterImportAction;
+  secondaryAction: ImportsCenterImportAction | null;
+};
+
+export type ImportsCenterEmptyData = {
+  screenState: 'empty';
+  portfolioId: string;
+  emptyState: EmptyState;
+  summary: { totalImports: number; pendingImports: number; completedImports: number; failedImports: number };
+  imports: [];
+};
+
+export type ImportsCenterReadyData = {
+  screenState: 'ready';
+  portfolioId: string;
+  summary: { totalImports: number; pendingImports: number; completedImports: number; failedImports: number };
+  imports: ImportsCenterImportItem[];
+};
+
+export type ImportsCenterData = ScreenStateRedirect | ImportsCenterEmptyData | ImportsCenterReadyData;
+export type ApiImportsCenterEnvelope = ApiEnvelope<ImportsCenterData>;
+
 // ===== Dashboard Home =====
 
 export type DashboardHero = {

--- a/apps/web/src/core/data/data_sources.ts
+++ b/apps/web/src/core/data/data_sources.ts
@@ -2,6 +2,7 @@ import type {
   ApiAnalysisEnvelope,
   ApiDashboardHomeEnvelope,
   ApiHoldingDetailEnvelope,
+  ApiImportsCenterEnvelope,
   ApiPortfolioEnvelope,
   ApiHistorySnapshotsEnvelope,
   ApiHistoryTimelineEnvelope,
@@ -36,6 +37,10 @@ export interface ProfileDataSource {
   putProfileContext(input: ProfileContextPutRequest): Promise<ApiProfileContextPutEnvelope>;
 }
 
+export interface ImportsCenterDataSource {
+  getImportsCenter(): Promise<ApiImportsCenterEnvelope>;
+}
+
 export interface AppDataSources {
   dashboard: DashboardDataSource;
   analysis: AnalysisDataSource;
@@ -43,5 +48,6 @@ export interface AppDataSources {
   portfolio: PortfolioDataSource;
   holdingDetail: HoldingDetailDataSource;
   profile: ProfileDataSource;
+  importsCenter: ImportsCenterDataSource;
 }
 

--- a/apps/web/src/core/data/mock/hml/imports_center.json
+++ b/apps/web/src/core/data/mock/hml/imports_center.json
@@ -1,0 +1,36 @@
+{
+  "ok": true,
+  "meta": {
+    "requestId": "req_hml_imports_center",
+    "timestamp": "2026-03-31T01:00:00Z",
+    "version": "v1"
+  },
+  "data": {
+    "screenState": "ready",
+    "portfolioId": "pfl_seed_balanced",
+    "summary": {
+      "totalImports": 1,
+      "pendingImports": 0,
+      "completedImports": 1,
+      "failedImports": 0
+    },
+    "imports": [
+      {
+        "id": "imp_hml_1",
+        "origin": "DOCUMENT_AI_PARSE",
+        "originLabel": "Documento assistido",
+        "status": "COMMITTED",
+        "statusLabel": "Concluída",
+        "fileName": "nota_corretagem.pdf",
+        "mimeType": "application/pdf",
+        "totals": { "totalRows": 9, "validRows": 9, "invalidRows": 0, "duplicateRows": 0 },
+        "createdAt": "2026-03-31T01:00:00Z",
+        "updatedAt": "2026-03-31T01:03:00Z",
+        "snapshot": { "id": "snp_bal_1", "referenceDate": "2026-03-31", "target": "/history/snapshots" },
+        "primaryAction": { "code": "open_preview", "title": "Ver importação", "target": "/imports/imp_hml_1/preview" },
+        "secondaryAction": { "code": "open_snapshot", "title": "Ver snapshot", "target": "/history/snapshots" }
+      }
+    ]
+  }
+}
+

--- a/apps/web/src/core/data/providers/http_provider.ts
+++ b/apps/web/src/core/data/providers/http_provider.ts
@@ -3,6 +3,7 @@ import type {
   ApiAnalysisEnvelope,
   ApiDashboardHomeEnvelope,
   ApiHoldingDetailEnvelope,
+  ApiImportsCenterEnvelope,
   ApiPortfolioEnvelope,
   ApiHistorySnapshotsEnvelope,
   ApiHistoryTimelineEnvelope,
@@ -66,6 +67,11 @@ export function createHttpDataSources(options: HttpProviderOptions): AppDataSour
           headers: { 'content-type': 'application/json' },
           body: JSON.stringify(input)
         });
+      }
+    },
+    importsCenter: {
+      async getImportsCenter(): Promise<ApiImportsCenterEnvelope> {
+        return await fetchJson<ApiImportsCenterEnvelope>(fetchImpl, `${baseUrl}/v1/history/imports`);
       }
     }
   };

--- a/apps/web/src/core/data/providers/mock_provider.ts
+++ b/apps/web/src/core/data/providers/mock_provider.ts
@@ -3,6 +3,7 @@ import type {
   ApiAnalysisEnvelope,
   ApiDashboardHomeEnvelope,
   ApiHoldingDetailEnvelope,
+  ApiImportsCenterEnvelope,
   ApiPortfolioEnvelope,
   ApiHistorySnapshotsEnvelope,
   ApiHistoryTimelineEnvelope,
@@ -105,6 +106,12 @@ export function createLocalMockDataSources(options: MockProviderOptions): AppDat
           meta: current.meta,
           data: rest
         };
+      }
+    }
+    ,
+    importsCenter: {
+      async getImportsCenter(): Promise<ApiImportsCenterEnvelope> {
+        return await loader.load<ApiImportsCenterEnvelope>(`${basePath}/imports_center.json`);
       }
     }
   };

--- a/apps/web/src/features/imports/ImportsCenterScreen.tsx
+++ b/apps/web/src/features/imports/ImportsCenterScreen.tsx
@@ -1,0 +1,163 @@
+import React, { useEffect, useState } from 'react';
+import type { AppDataSources } from '../../core/data/data_sources';
+import type { ImportsCenterData, ImportsCenterImportItem } from '../../core/data/contracts';
+import { ShellLayout } from '../../app/ShellLayout';
+
+export interface ImportsCenterScreenProps {
+  dataSources: AppDataSources;
+  onGoToTarget(path: string): void;
+}
+
+export function ImportsCenterScreen(props: ImportsCenterScreenProps): JSX.Element {
+  const [state, setState] = useState<
+    | { kind: 'loading' }
+    | { kind: 'error'; message: string }
+    | { kind: 'ready'; data: ImportsCenterData }
+  >({ kind: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ kind: 'loading' });
+    (async () => {
+      try {
+        const res = await props.dataSources.importsCenter.getImportsCenter();
+        if (cancelled) return;
+        if (!res.ok) {
+          setState({ kind: 'error', message: `${res.error.code}: ${res.error.message}` });
+          return;
+        }
+        setState({ kind: 'ready', data: res.data });
+      } catch (e) {
+        if (cancelled) return;
+        setState({ kind: 'error', message: e instanceof Error ? e.message : 'Falha ao carregar' });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [props.dataSources]);
+
+  return (
+    <ShellLayout title="Importacoes" activeRouteId="imports" onNavigate={(href) => props.onGoToTarget(href)}>
+      {state.kind === 'loading' ? (
+        <div className="card" style={{ padding: 16 }}>
+          Carregando...
+        </div>
+      ) : state.kind === 'error' ? (
+        <div className="card" style={{ padding: 16 }}>
+          <div style={{ fontWeight: 900, marginBottom: 6 }}>Nao foi possivel carregar</div>
+          <div style={{ color: 'var(--c-slate)' }}>{state.message}</div>
+        </div>
+      ) : (
+        <ImportsContent data={state.data} onGoToTarget={props.onGoToTarget} />
+      )}
+    </ShellLayout>
+  );
+}
+
+function ImportsContent(props: { data: ImportsCenterData; onGoToTarget(path: string): void }): JSX.Element {
+  const d = props.data;
+
+  if (d.screenState === 'redirect_onboarding') {
+    return (
+      <div className="card" style={{ padding: 16 }}>
+        <div style={{ fontWeight: 900, marginBottom: 6 }}>Antes de importar</div>
+        <div style={{ color: 'var(--c-slate)' }}>Complete seu contexto para escolher o melhor caminho.</div>
+      </div>
+    );
+  }
+
+  if (d.screenState === 'empty') {
+    return (
+      <div className="card" style={{ padding: 16 }}>
+        <div style={{ fontWeight: 900, marginBottom: 6 }}>{d.emptyState.title}</div>
+        <div style={{ color: 'var(--c-slate)', lineHeight: 1.55 }}>{d.emptyState.body}</div>
+        <div style={{ marginTop: 12 }}>
+          <button className="btn btnPrimary" onClick={() => props.onGoToTarget(d.emptyState.target)}>
+            {d.emptyState.ctaLabel}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: 'grid', gap: 12 }}>
+      <div className="card" style={{ padding: 16 }}>
+        <div style={{ fontWeight: 900, marginBottom: 10 }}>Resumo</div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, minmax(0, 1fr))', gap: 10 }}>
+          <Kpi label="Total" value={String(d.summary.totalImports)} />
+          <Kpi label="Pendentes" value={String(d.summary.pendingImports)} />
+          <Kpi label="Concluidas" value={String(d.summary.completedImports)} />
+          <Kpi label="Falhas" value={String(d.summary.failedImports)} />
+        </div>
+      </div>
+
+      <section className="card" style={{ padding: 16 }}>
+        <div style={{ fontWeight: 900, marginBottom: 10 }}>Importacoes</div>
+        <div style={{ display: 'grid', gap: 10 }}>
+          {d.imports.map((it) => (
+            <ImportRow key={it.id} it={it} onGoToTarget={props.onGoToTarget} />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function ImportRow(props: { it: ImportsCenterImportItem; onGoToTarget(path: string): void }): JSX.Element {
+  const it = props.it;
+  const tone =
+    it.status === 'FAILED' ? { bg: 'rgba(232,92,92,0.16)', border: 'rgba(232,92,92,0.35)' }
+      : it.status === 'COMMITTED' ? { bg: 'rgba(111,207,151,0.16)', border: 'rgba(111,207,151,0.35)' }
+        : { bg: 'rgba(242,181,68,0.18)', border: 'rgba(242,181,68,0.35)' };
+
+  return (
+    <div style={{ padding: 14, borderRadius: 14, border: `1px solid ${tone.border}`, background: tone.bg }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap', alignItems: 'baseline' }}>
+        <div>
+          <div style={{ fontWeight: 900 }}>{it.originLabel}</div>
+          <div style={{ marginTop: 4, fontSize: 12, color: 'var(--c-slate)' }}>
+            {it.statusLabel}
+            {it.fileName ? ` • ${it.fileName}` : ''}
+            {` • ${formatDateTime(it.createdAt)}`}
+          </div>
+        </div>
+        <div style={{ fontSize: 12, color: 'var(--c-slate)' }}>
+          Linhas: {it.totals.validRows}/{it.totals.totalRows} {' • '} dup: {it.totals.duplicateRows}
+        </div>
+      </div>
+
+      <div style={{ marginTop: 12, display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+        <button className="btn btnPrimary" onClick={() => props.onGoToTarget(it.primaryAction.target)}>
+          {it.primaryAction.title}
+        </button>
+        {it.secondaryAction ? (
+          <button className="btn btnGhost" onClick={() => props.onGoToTarget(it.secondaryAction!.target)}>
+            {it.secondaryAction.title}
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function Kpi(props: { label: string; value: string }): JSX.Element {
+  return (
+    <div style={{ padding: 12, borderRadius: 14, border: '1px solid rgba(11,18,24,0.10)', background: 'rgba(255,255,255,0.7)' }}>
+      <div style={{ fontSize: 12, color: 'var(--c-slate)', marginBottom: 6, fontWeight: 800 }}>{props.label}</div>
+      <div style={{ fontWeight: 900, fontSize: 16, letterSpacing: -0.2 }}>{props.value}</div>
+    </div>
+  );
+}
+
+function formatDateTime(input: string | null): string {
+  if (!input) return '—';
+  try {
+    const d = new Date(input);
+    return new Intl.DateTimeFormat('pt-BR', { dateStyle: 'medium', timeStyle: 'short' }).format(d);
+  } catch {
+    return input;
+  }
+}
+


### PR DESCRIPTION
Atende #30 (US019).\n\nO que entra:\n- Tela /imports (Central de Importacoes) com resumo + lista de importacoes e CTAs\n- Contrato TS ApiImportsCenterEnvelope copiado do starter (/v1/history/imports)\n- AppDataSources.importsCenter + HttpProvider + MockProvider + mocks local/hml\n\nObs: targets como /imports/:id/preview e /imports/entry ficam prontos para as proximas telas do fluxo de importacao.