### PR TITLE
Web: Radar/Histórico com navegação coerente + redirectTo

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -115,10 +115,7 @@ export function App(): JSX.Element {
     return (
       <RadarScreen
         dataSources={dataSources}
-        onBack={() => navigate('/home')}
         onGoToTarget={(path) => navigate(path)}
-        onGoToHome={() => navigate('/home')}
-        onGoToPortfolio={() => navigate('/portfolio')}
       />
     );
   }

--- a/apps/web/src/features/history/HistoryScreen.tsx
+++ b/apps/web/src/features/history/HistoryScreen.tsx
@@ -63,6 +63,11 @@ function HistoryContent(props: { data: HistoryTimelineData; onGoToTarget(path: s
       <div className="card" style={{ padding: 16 }}>
         <div style={{ fontWeight: 900, marginBottom: 6 }}>Antes de tudo</div>
         <div style={{ color: 'var(--c-slate)' }}>Complete seu contexto para gerar leitura temporal.</div>
+        <div style={{ marginTop: 12 }}>
+          <button className="btn btnPrimary" onClick={() => props.onGoToTarget(d.redirectTo)}>
+            Completar contexto
+          </button>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
Resolve TEC-045 (#214) e melhora US021 (#32).\n\nO que muda:\n- Radar: Shell nav delega qualquer href via onGoToTarget e o estado redirect_onboarding tem CTA real para d.redirectTo.\n- Historico: estado redirect_onboarding agora tem CTA para d.redirectTo.\n\nResultado:\n- Navegacao entre Home/Radar/Historico fica consistente com o contrato do backend, sem rotas mortas.