### PR TITLE
TEC: .gitignore (node/build/tooling tmp)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,13 @@ build/
 .vite/
 .next/
 coverage/
+*.tsbuildinfo
 
 # Cloudflare / wrangler
 .wrangler/
+
+# Logs
+*.log
 
 # OS / editor
 .DS_Store


### PR DESCRIPTION
Adiciona .gitignore para reduzir ruido e evitar comitar artefatos temporarios (node_modules, dist/build, envs e tooling/_tmp).