### PR TITLE
CI: habilitar deploy controlado (Worker + D1)

### DIFF
--- a/.github/workflows/d1-execute.yml
+++ b/.github/workflows/d1-execute.yml
@@ -1,0 +1,79 @@
+name: D1 Execute (Controlled)
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_env:
+        description: "Ambiente do D1"
+        required: true
+        type: choice
+        options:
+          - hml
+          - production
+      mode:
+        description: "Modo de execucao"
+        required: true
+        type: choice
+        options:
+          - file
+          - command
+      sql_file:
+        description: "Caminho do arquivo SQL (somente quando mode=file)"
+        required: false
+        default: "database/d1/schema.sql"
+      sql_command:
+        description: "Comando SQL inline (somente quando mode=command)"
+        required: false
+        default: ""
+      ref:
+        description: "Branch/tag/sha para usar como fonte do SQL (opcional). Vazio = ref atual."
+        required: false
+        default: ""
+
+concurrency:
+  group: d1-exec-${{ inputs.target_env }}
+  cancel-in-progress: false
+
+jobs:
+  d1:
+    name: D1 Execute (${{ inputs.target_env }})
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.target_env }}
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install (worker)
+        working-directory: 04_STARTER_BACKEND/esquilo_cloudflare_d1_starter
+        run: npm ci
+
+      - name: Execute SQL (remote)
+        working-directory: 04_STARTER_BACKEND/esquilo_cloudflare_d1_starter
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WRANGLER_SEND_METRICS: "false"
+        run: |
+          set -euo pipefail
+          if [ "${{ inputs.mode }}" = "file" ]; then
+            echo "[d1] file=${{ inputs.sql_file }}"
+            npx wrangler d1 execute DB --env "${{ inputs.target_env }}" --file="../../${{ inputs.sql_file }}" --remote --yes
+          else
+            if [ -z "${{ inputs.sql_command }}" ]; then
+              echo "[d1] sql_command vazio (mode=command)."
+              exit 1
+            fi
+            echo "[d1] command"
+            npx wrangler d1 execute DB --env "${{ inputs.target_env }}" --command "${{ inputs.sql_command }}" --remote --yes
+          fi
+

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,0 +1,71 @@
+name: Deploy Worker (Controlled)
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_env:
+        description: "Ambiente de deploy (controlado)"
+        required: true
+        type: choice
+        options:
+          - hml
+          - production
+      ref:
+        description: "Branch/tag/sha para deploy (opcional). Vazio = ref atual do workflow."
+        required: false
+        default: ""
+
+concurrency:
+  group: deploy-worker-${{ inputs.target_env }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy (${{ inputs.target_env }})
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.target_env }}
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install (worker)
+        working-directory: 04_STARTER_BACKEND/esquilo_cloudflare_d1_starter
+        run: npm ci
+
+      - name: Install (web)
+        working-directory: apps/web/app
+        run: npm ci
+
+      - name: Deploy (build gate + wrangler)
+        working-directory: 04_STARTER_BACKEND/esquilo_cloudflare_d1_starter
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WRANGLER_SEND_METRICS: "false"
+        run: |
+          if [ "${{ inputs.target_env }}" = "production" ]; then
+            npm run deploy:prod
+          else
+            npm run deploy:hml
+          fi
+
+      - name: Rollback (best-effort, production only)
+        if: failure() && inputs.target_env == 'production'
+        continue-on-error: true
+        working-directory: 04_STARTER_BACKEND/esquilo_cloudflare_d1_starter
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WRANGLER_SEND_METRICS: "false"
+        run: npm run rollback:prod
+


### PR DESCRIPTION
Habilita workflows manuais para deploy controlado via Wrangler (build gate + rollback best-effort) e execucao controlada de SQL no D1.\n\nNecessario para a Release 0.1 (Noz de Ouro) rodar deploy E2E sem depender do terminal local.