### PR TITLE
CI: validar secrets Cloudflare no Actions

### DIFF
--- a/.github/workflows/d1-execute.yml
+++ b/.github/workflows/d1-execute.yml
@@ -57,11 +57,26 @@ jobs:
         working-directory: 04_STARTER_BACKEND/esquilo_cloudflare_d1_starter
         run: npm ci
 
+      - name: Validate Cloudflare secrets
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CLOUDFLARE_API_TOKEN}" ]; then
+            echo "Missing secret: CLOUDFLARE_API_TOKEN (or CF_API_TOKEN)." >&2
+            exit 1
+          fi
+          if [ -z "${CLOUDFLARE_ACCOUNT_ID}" ]; then
+            echo "Missing secret: CLOUDFLARE_ACCOUNT_ID (or CF_ACCOUNT_ID)." >&2
+            exit 1
+          fi
+
       - name: Execute SQL (remote)
         working-directory: 04_STARTER_BACKEND/esquilo_cloudflare_d1_starter
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID }}
           WRANGLER_SEND_METRICS: "false"
         run: |
           set -euo pipefail

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -33,6 +33,21 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
+      - name: Validate Cloudflare secrets
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CLOUDFLARE_API_TOKEN}" ]; then
+            echo "Missing secret: CLOUDFLARE_API_TOKEN (or CF_API_TOKEN)." >&2
+            exit 1
+          fi
+          if [ -z "${CLOUDFLARE_ACCOUNT_ID}" ]; then
+            echo "Missing secret: CLOUDFLARE_ACCOUNT_ID (or CF_ACCOUNT_ID)." >&2
+            exit 1
+          fi
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -49,8 +64,8 @@ jobs:
       - name: Deploy (build gate + wrangler)
         working-directory: 04_STARTER_BACKEND/esquilo_cloudflare_d1_starter
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID }}
           WRANGLER_SEND_METRICS: "false"
         run: |
           if [ "${{ inputs.target_env }}" = "production" ]; then
@@ -64,8 +79,8 @@ jobs:
         continue-on-error: true
         working-directory: 04_STARTER_BACKEND/esquilo_cloudflare_d1_starter
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID }}
           WRANGLER_SEND_METRICS: "false"
         run: npm run rollback:prod
 


### PR DESCRIPTION
Evita falhas silenciosas no deploy controlado: valida CLOUDFLARE_API_TOKEN/CLOUDFLARE_ACCOUNT_ID e aceita aliases CF_API_TOKEN/CF_ACCOUNT_ID nos workflows.\n\nNecessario para Release 0.1 (Noz de Ouro) conseguir rodar deploy via Actions.