### PR TITLE
fix(worker): configure production D1 database ID

### DIFF
--- a/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/wrangler.toml
+++ b/04_STARTER_BACKEND/esquilo_cloudflare_d1_starter/wrangler.toml
@@ -61,4 +61,4 @@ EXTERNAL_REFERENCES_BRAPI_BASE_URL = "https://brapi.dev/api"
 [[env.production.d1_databases]]
 binding = "DB"
 database_name = "esquilo-invest"
-database_id = "REPLACE_WITH_PROD_D1_DATABASE_ID"
+database_id = "2a4849fa-e980-4540-bd60-514b740287d3"


### PR DESCRIPTION
## Summary
- Fixed placeholder D1 database ID in production wrangler.toml configuration
- The Worker was pointing to a placeholder instead of the actual esquilo-invest database

## Impact
Resolves internal API errors on login and all authenticated endpoints. The Worker now correctly binds to the production D1 database.

## Testing
- [x] Password hashes regenerated with correct iteration count (60000)
- [x] Database schema and seed data verified in D1
- [ ] Login flow to be tested after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)